### PR TITLE
:hammer: feat: add repository methods for pool management

### DIFF
--- a/src/repositories/pools/IPoolsRepository.ts
+++ b/src/repositories/pools/IPoolsRepository.ts
@@ -8,4 +8,8 @@ export interface IPoolsRepository {
   findByInviteCode(inviteCode: string): Promise<Pool | null>;
   findByCreatorId(creatorId: string): Promise<Pool[]>;
   findByParticipantId(userId: string): Promise<Pool[]>;
+  getScoringRules(poolId: number): Promise<ScoringRule[]>;
+  getPoolParticipants(poolId: number): Promise<{ userId: string }[]>;
+  getPool(id: number): Promise<Pool | null>;
+  update(id: number, data: Prisma.PoolUpdateInput): Promise<Pool>;
 }

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -26,6 +26,51 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
     return pool;
   }
 
+  async getScoringRules(poolId: number): Promise<ScoringRule[]> {
+    return this.scoringRules.filter((rule) => rule.poolId === poolId);
+  }
+
+  async getPoolParticipants(poolId: number): Promise<{ poolId: number; userId: string }[]> {
+    return this.participants.filter((participant) => participant.poolId === poolId);
+  }
+
+  async getPool(poolId: number): Promise<Pool | null> {
+    return this.findById(poolId);
+  }
+
+  async update(id: number, data: Prisma.PoolUpdateInput): Promise<Pool> {
+    const poolIndex = this.pools.findIndex((pool) => pool.id === id);
+    if (poolIndex === -1) {
+      throw new Error('Pool not found');
+    }
+
+    const updatedPool: Pool = {
+      ...this.pools[poolIndex],
+      name: typeof data.name === 'string' ? data.name : this.pools[poolIndex].name,
+      description:
+        typeof data.description === 'string' ? data.description : this.pools[poolIndex].description,
+      isPrivate:
+        typeof data.isPrivate === 'boolean' ? data.isPrivate : this.pools[poolIndex].isPrivate,
+      inviteCode:
+        typeof data.inviteCode === 'string' ? data.inviteCode : this.pools[poolIndex].inviteCode,
+      maxParticipants:
+        typeof data.maxParticipants === 'number'
+          ? data.maxParticipants
+          : this.pools[poolIndex].maxParticipants,
+      registrationDeadline:
+        data.registrationDeadline instanceof Date
+          ? data.registrationDeadline
+          : this.pools[poolIndex].registrationDeadline,
+      tournamentId: data.tournament?.connect?.id ?? this.pools[poolIndex].tournamentId,
+      creatorId: data.creator?.connect?.id ?? this.pools[poolIndex].creatorId,
+      createdAt: this.pools[poolIndex].createdAt,
+      id: this.pools[poolIndex].id,
+    };
+
+    this.pools[poolIndex] = updatedPool as Pool;
+    return updatedPool as Pool;
+  }
+
   async createScoringRules(data: Prisma.ScoringRuleCreateInput): Promise<ScoringRule> {
     const newId = this.scoringRules.length + 1;
 

--- a/src/repositories/pools/PrismaPoolsRepository.ts
+++ b/src/repositories/pools/PrismaPoolsRepository.ts
@@ -3,6 +3,39 @@ import { prisma } from '../../lib/prisma';
 import { IPoolsRepository } from './IPoolsRepository';
 
 export class PrismaPoolsRepository implements IPoolsRepository {
+  async getScoringRules(poolId: number): Promise<ScoringRule[]> {
+    const scoringRules = await prisma.scoringRule.findMany({
+      where: { poolId },
+    });
+
+    return scoringRules;
+  }
+
+  async getPoolParticipants(poolId: number): Promise<{ userId: string }[]> {
+    const participants = await prisma.poolParticipant.findMany({
+      where: { poolId },
+      select: { userId: true },
+    });
+
+    return participants;
+  }
+
+  async getPool(id: number): Promise<Pool | null> {
+    const pool = await prisma.pool.findUnique({
+      where: { id },
+    });
+
+    return pool;
+  }
+
+  async update(id: number, data: Prisma.PoolUpdateInput): Promise<Pool> {
+    const pool = await prisma.pool.update({
+      where: { id },
+      data,
+    });
+
+    return pool;
+  }
   async create(data: Prisma.PoolCreateInput): Promise<Pool> {
     const pool = await prisma.pool.create({
       data,

--- a/src/useCases/pools/factory/makeUpdatePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeUpdatePoolUseCase.ts
@@ -1,0 +1,11 @@
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { UpdatePoolUseCase } from '../updatePoolUseCase';
+
+export function makeUpdatePoolUseCase() {
+  const poolsRepository = new PrismaPoolsRepository();
+  const usersRepository = new PrismaUsersRepository();
+  const useCase = new UpdatePoolUseCase(poolsRepository, usersRepository);
+
+  return useCase;
+}

--- a/src/useCases/pools/updatePoolUseCase.spec.ts
+++ b/src/useCases/pools/updatePoolUseCase.spec.ts
@@ -1,0 +1,160 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { UpdatePoolUseCase } from './updatePoolUseCase';
+
+let poolsRepository: IPoolsRepository;
+let usersRepository: IUsersRepository;
+let sut: UpdatePoolUseCase;
+
+describe('Update Pool Use Case', () => {
+  beforeEach(() => {
+    poolsRepository = new InMemoryPoolsRepository();
+    usersRepository = new InMemoryUsersRepository();
+    sut = new UpdatePoolUseCase(poolsRepository, usersRepository);
+  });
+
+  it('should be able to update a pool', async () => {
+    const user = await usersRepository.create({
+      email: 'user@email.com',
+      fullName: 'John Doe',
+      accountProvider: 'EMAIL',
+    });
+
+    const pool = await poolsRepository.create({
+      name: 'Original Pool Name',
+      description: 'Original description',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: user.id } },
+      isPrivate: false,
+    });
+
+    const updatedPool = await sut.execute({
+      poolId: pool.id,
+      userId: user.id,
+      name: 'Updated Pool Name',
+      description: 'Updated description',
+      isPrivate: true,
+      maxParticipants: 20,
+    });
+
+    expect(updatedPool.name).toEqual('Updated Pool Name');
+    expect(updatedPool.description).toEqual('Updated description');
+    expect(updatedPool.isPrivate).toEqual(true);
+    expect(updatedPool.maxParticipants).toEqual(20);
+  });
+
+  it('should not be able to update a pool with non-existing user', async () => {
+    const pool = await poolsRepository.create({
+      name: 'Original Pool Name',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: 'existing-user-id' } },
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userId: 'non-existing-user-id',
+        name: 'Updated Pool Name',
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not be able to update a non-existing pool', async () => {
+    const user = await usersRepository.create({
+      email: 'user@email.com',
+      fullName: 'John Doe',
+      accountProvider: 'EMAIL',
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: 999,
+        userId: user.id,
+        name: 'Updated Pool Name',
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not allow a user to update a pool they did not create', async () => {
+    const creator = await usersRepository.create({
+      email: 'creator@email.com',
+      fullName: 'Pool Creator',
+      accountProvider: 'EMAIL',
+    });
+
+    const otherUser = await usersRepository.create({
+      email: 'other@email.com',
+      fullName: 'Other User',
+      accountProvider: 'EMAIL',
+    });
+
+    const pool = await poolsRepository.create({
+      name: 'Original Pool Name',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: creator.id } },
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userId: otherUser.id,
+        name: 'Updated Pool Name',
+      })
+    ).rejects.toThrow('Only the pool creator can update the pool');
+  });
+
+  it('should only update the fields that are provided', async () => {
+    const user = await usersRepository.create({
+      email: 'user@email.com',
+      fullName: 'John Doe',
+      accountProvider: 'EMAIL',
+    });
+
+    const pool = await poolsRepository.create({
+      name: 'Original Pool Name',
+      description: 'Original description',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: user.id } },
+      isPrivate: false,
+    });
+
+    const updatedPool = await sut.execute({
+      poolId: pool.id,
+      userId: user.id,
+      name: 'Updated Pool Name',
+      // No other fields provided
+    });
+
+    expect(updatedPool.name).toEqual('Updated Pool Name');
+    expect(updatedPool.description).toEqual('Original description');
+    expect(updatedPool.isPrivate).toEqual(false);
+  });
+
+  it('should be able to update registration deadline', async () => {
+    const user = await usersRepository.create({
+      email: 'user@email.com',
+      fullName: 'John Doe',
+      accountProvider: 'EMAIL',
+    });
+
+    const pool = await poolsRepository.create({
+      name: 'Original Pool Name',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: user.id } },
+    });
+
+    const newDeadline = new Date('2023-12-31T23:59:59Z');
+
+    const updatedPool = await sut.execute({
+      poolId: pool.id,
+      userId: user.id,
+      registrationDeadline: newDeadline,
+    });
+
+    expect(updatedPool.registrationDeadline).toEqual(newDeadline);
+  });
+});

--- a/src/useCases/pools/updatePoolUseCase.ts
+++ b/src/useCases/pools/updatePoolUseCase.ts
@@ -1,0 +1,54 @@
+import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
+import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
+import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+
+interface IUpdatePoolRequest {
+  poolId: number;
+  userId: string; // User requesting the update (for authorization)
+  name?: string;
+  description?: string;
+  isPrivate?: boolean;
+  maxParticipants?: number;
+  registrationDeadline?: Date;
+}
+
+export class UpdatePoolUseCase {
+  constructor(
+    private poolsRepository: IPoolsRepository,
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute({
+    poolId,
+    userId,
+    name,
+    description,
+    isPrivate,
+    maxParticipants,
+    registrationDeadline,
+  }: IUpdatePoolRequest) {
+    const user = await this.usersRepository.findById(userId);
+    if (!user) {
+      throw new ResourceNotFoundError('User not found');
+    }
+
+    const pool = await this.poolsRepository.findById(poolId);
+    if (!pool) {
+      throw new ResourceNotFoundError('Pool not found');
+    }
+
+    if (pool.creatorId !== userId) {
+      throw new Error('Only the pool creator can update the pool');
+    }
+
+    const updatedPool = await this.poolsRepository.update(poolId, {
+      name,
+      description,
+      isPrivate,
+      maxParticipants,
+      registrationDeadline,
+    });
+
+    return updatedPool;
+  }
+}


### PR DESCRIPTION
Add new methods to the IPoolsRepository interface and implement them in both InMemoryPoolsRepository and PrismaPoolsRepository:
- getScoringRules: retrieve scoring rules for a specific pool
- getPoolParticipants: get all participants in a pool
- getPool: get a single pool by ID
- update: modify pool properties