### PR TITLE
:hammer: feat: Add functionality to leave pools and remove users from pools

### DIFF
--- a/src/http/controllers/pools/leavePoolController.ts
+++ b/src/http/controllers/pools/leavePoolController.ts
@@ -1,0 +1,28 @@
+import { makeLeavePoolUseCase } from '@/useCases/pools/factory/makeLeavePoolUseCase';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+export async function leavePoolController(request: FastifyRequest, reply: FastifyReply) {
+  const leavePoolParamsSchema = z.object({
+    poolId: z.coerce.number(),
+  });
+
+  const { poolId } = leavePoolParamsSchema.parse(request.params);
+  const userId = request.user.sub;
+
+  try {
+    const leavePoolUseCase = makeLeavePoolUseCase();
+    await leavePoolUseCase.execute({
+      poolId,
+      userId,
+    });
+
+    return reply.status(200).send();
+  } catch (error) {
+    if (error instanceof Error) {
+      return reply.status(400).send({ message: error.message });
+    }
+
+    return reply.status(500).send({ message: 'Internal server error' });
+  }
+}

--- a/src/http/controllers/pools/removeUserFromPoolController.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.ts
@@ -1,0 +1,30 @@
+import { makeRemoveUserFromPoolUseCase } from '@/useCases/pools/factory/makeRemoveUserFromPoolUseCase';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+export async function removeUserFromPoolController(request: FastifyRequest, reply: FastifyReply) {
+  const removeUserFromPoolParamsSchema = z.object({
+    poolId: z.coerce.number(),
+    userId: z.string().uuid(),
+  });
+
+  const { poolId, userId: userIdToRemove } = removeUserFromPoolParamsSchema.parse(request.params);
+  const creatorId = request.user.sub;
+
+  try {
+    const removeUserFromPoolUseCase = makeRemoveUserFromPoolUseCase();
+    await removeUserFromPoolUseCase.execute({
+      poolId,
+      userIdToRemove,
+      creatorId,
+    });
+
+    return reply.status(200).send();
+  } catch (error) {
+    if (error instanceof Error) {
+      return reply.status(400).send({ message: error.message });
+    }
+
+    return reply.status(500).send({ message: 'Internal server error' });
+  }
+}

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -1,11 +1,15 @@
 import { FastifyInstance } from 'fastify';
 import { getPoolUsersController } from '../controllers/pools/getPoolUsersController';
 import { JoinPoolController } from '../controllers/pools/joinPoolController';
+import { leavePoolController } from '../controllers/pools/leavePoolController';
+import { removeUserFromPoolController } from '../controllers/pools/removeUserFromPoolController';
 import { verifyJwt } from '../middlewares/verifyJWT';
 
 export async function UserRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
   app.post('/pools/join', JoinPoolController);
+  app.post('/pools/:poolId/leave', leavePoolController);
+  app.delete('/pools/:poolId/users/:userId', removeUserFromPoolController);
   app.get('/pools/:poolId/users', getPoolUsersController);
 }

--- a/src/repositories/pools/IPoolsRepository.ts
+++ b/src/repositories/pools/IPoolsRepository.ts
@@ -8,6 +8,7 @@ export interface IPoolsRepository {
   create(data: Prisma.PoolCreateInput): Promise<Pool>;
   createScoringRules(data: Prisma.ScoringRuleCreateInput): Promise<ScoringRule>;
   addParticipant(data: { poolId: number; userId: string }): Promise<void>;
+  removeParticipant(data: { poolId: number; userId: string }): Promise<void>;
   findById(id: number): Promise<Pool | null>;
   findByInviteCode(inviteCode: string): Promise<Pool | null>;
   findByCreatorId(creatorId: string): Promise<Pool[]>;

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -130,4 +130,16 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
       (pool) => participantPoolIds.includes(pool.id) || pool.creatorId === userId
     );
   }
+
+  async removeParticipant({ poolId, userId }: { poolId: number; userId: string }) {
+    const participantIndex = this.participants.findIndex(
+      (participant) => participant.poolId === poolId && participant.userId === userId
+    );
+
+    if (participantIndex === -1) {
+      throw new Error('Participant not found');
+    }
+
+    this.participants.splice(participantIndex, 1);
+  }
 }

--- a/src/repositories/pools/PrismaPoolsRepository.ts
+++ b/src/repositories/pools/PrismaPoolsRepository.ts
@@ -96,4 +96,15 @@ export class PrismaPoolsRepository implements IPoolsRepository {
 
     return poolParticipants.map((participant) => participant.pool);
   }
+
+  async removeParticipant({ poolId, userId }: { poolId: number; userId: string }) {
+    await prisma.poolParticipant.delete({
+      where: {
+        poolId_userId: {
+          poolId,
+          userId,
+        },
+      },
+    });
+  }
 }

--- a/src/useCases/pools/factory/makeLeavePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeLeavePoolUseCase.ts
@@ -1,0 +1,11 @@
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { LeavePoolUseCase } from '../leavePoolUseCase';
+
+export function makeLeavePoolUseCase() {
+  const poolsRepository = new PrismaPoolsRepository();
+  const usersRepository = new PrismaUsersRepository();
+  const leavePoolUseCase = new LeavePoolUseCase(poolsRepository, usersRepository);
+
+  return leavePoolUseCase;
+}

--- a/src/useCases/pools/factory/makeRemoveUserFromPoolUseCase.ts
+++ b/src/useCases/pools/factory/makeRemoveUserFromPoolUseCase.ts
@@ -1,0 +1,11 @@
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { RemoveUserFromPoolUseCase } from '../removeUserFromPoolUseCase';
+
+export function makeRemoveUserFromPoolUseCase() {
+  const poolsRepository = new PrismaPoolsRepository();
+  const usersRepository = new PrismaUsersRepository();
+  const removeUserFromPoolUseCase = new RemoveUserFromPoolUseCase(poolsRepository, usersRepository);
+
+  return removeUserFromPoolUseCase;
+}

--- a/src/useCases/pools/leavePoolUseCase.spec.ts
+++ b/src/useCases/pools/leavePoolUseCase.spec.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
+import { InMemoryPoolsRepository } from '../../repositories/pools/InMemoryPoolsRepository';
+import { InMemoryTournamentsRepository } from '../../repositories/tournaments/InMemoryTournamentsRepository';
+import { InMemoryUsersRepository } from '../../repositories/users/InMemoryUsersRepository';
+import { LeavePoolUseCase } from './leavePoolUseCase';
+
+let poolsRepository: InMemoryPoolsRepository;
+let usersRepository: InMemoryUsersRepository;
+let tournamentsRepository: InMemoryTournamentsRepository;
+let sut: LeavePoolUseCase;
+
+describe('Leave Pool Use Case', () => {
+  beforeEach(() => {
+    poolsRepository = new InMemoryPoolsRepository();
+    usersRepository = new InMemoryUsersRepository();
+    tournamentsRepository = new InMemoryTournamentsRepository();
+    sut = new LeavePoolUseCase(poolsRepository, usersRepository);
+  });
+
+  it('should be able to leave a pool', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a participant user
+    const participant = await usersRepository.create({
+      email: 'participant@example.com',
+      fullName: 'Participant User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+      maxParticipants: 10,
+      registrationDeadline: new Date(Date.now() + 1000 * 60 * 60 * 24), // tomorrow
+    });
+
+    // Add participant to the pool
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: participant.id,
+    });
+
+    // Check if participant is in the pool
+    let participants = await poolsRepository.getPoolParticipants(pool.id);
+    expect(participants).toHaveLength(1);
+    expect(participants[0].userId).toBe(participant.id);
+
+    // Leave the pool
+    await sut.execute({
+      poolId: pool.id,
+      userId: participant.id,
+    });
+
+    // Check if participant is no longer in the pool
+    participants = await poolsRepository.getPoolParticipants(pool.id);
+    expect(participants).toHaveLength(0);
+  });
+
+  it('should not be able to leave a pool if user is not found', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userId: 'non-existent-user-id',
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not be able to leave a pool if pool is not found', async () => {
+    // Create a user
+    const user = await usersRepository.create({
+      email: 'user@example.com',
+      fullName: 'Test User',
+      passwordHash: 'hash',
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: 999,
+        userId: user.id,
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not be able to leave a pool if user is not a participant', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a non-participant user
+    const nonParticipant = await usersRepository.create({
+      email: 'nonparticipant@example.com',
+      fullName: 'Non Participant User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userId: nonParticipant.id,
+      })
+    ).rejects.toThrow('User is not a participant in this pool');
+  });
+
+  it('should not be able to leave a pool if user is the creator', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+    });
+
+    // Add creator as participant (this might happen automatically in a real scenario)
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: creator.id,
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userId: creator.id,
+      })
+    ).rejects.toThrow('Pool creator cannot leave their own pool');
+  });
+});

--- a/src/useCases/pools/leavePoolUseCase.ts
+++ b/src/useCases/pools/leavePoolUseCase.ts
@@ -1,0 +1,50 @@
+import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
+import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
+import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+
+interface ILeavePoolRequest {
+  poolId: number;
+  userId: string;
+}
+
+export class LeavePoolUseCase {
+  constructor(
+    private poolsRepository: IPoolsRepository,
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute({ poolId, userId }: ILeavePoolRequest) {
+    // Verify user exists
+    const user = await this.usersRepository.findById(userId);
+    if (!user) {
+      throw new ResourceNotFoundError('User not found');
+    }
+
+    // Verify pool exists
+    const pool = await this.poolsRepository.findById(poolId);
+    if (!pool) {
+      throw new ResourceNotFoundError('Pool not found');
+    }
+
+    // Check if user is a participant
+    const participants = await this.poolsRepository.getPoolParticipants(poolId);
+    const isParticipant = participants.some((participant) => participant.userId === userId);
+
+    if (!isParticipant) {
+      throw new Error('User is not a participant in this pool');
+    }
+
+    // Check if user is the creator (creators cannot leave their own pools)
+    if (pool.creatorId === userId) {
+      throw new Error('Pool creator cannot leave their own pool');
+    }
+
+    // Remove user from pool participants
+    await this.poolsRepository.removeParticipant({
+      poolId,
+      userId,
+    });
+
+    return pool;
+  }
+}

--- a/src/useCases/pools/removeUserFromPoolUseCase.spec.ts
+++ b/src/useCases/pools/removeUserFromPoolUseCase.spec.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
+import { InMemoryPoolsRepository } from '../../repositories/pools/InMemoryPoolsRepository';
+import { InMemoryTournamentsRepository } from '../../repositories/tournaments/InMemoryTournamentsRepository';
+import { InMemoryUsersRepository } from '../../repositories/users/InMemoryUsersRepository';
+import { RemoveUserFromPoolUseCase } from './removeUserFromPoolUseCase';
+
+let poolsRepository: InMemoryPoolsRepository;
+let usersRepository: InMemoryUsersRepository;
+let tournamentsRepository: InMemoryTournamentsRepository;
+let sut: RemoveUserFromPoolUseCase;
+
+describe('Remove User From Pool Use Case', () => {
+  beforeEach(() => {
+    poolsRepository = new InMemoryPoolsRepository();
+    usersRepository = new InMemoryUsersRepository();
+    tournamentsRepository = new InMemoryTournamentsRepository();
+    sut = new RemoveUserFromPoolUseCase(poolsRepository, usersRepository);
+  });
+
+  it('should be able to remove a user from a pool', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a participant user
+    const participant = await usersRepository.create({
+      email: 'participant@example.com',
+      fullName: 'Participant User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+      maxParticipants: 10,
+      registrationDeadline: new Date(Date.now() + 1000 * 60 * 60 * 24), // tomorrow
+    });
+
+    // Add participant to the pool
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: participant.id,
+    });
+
+    // Check if participant is in the pool
+    let participants = await poolsRepository.getPoolParticipants(pool.id);
+    expect(participants).toHaveLength(1);
+    expect(participants[0].userId).toBe(participant.id);
+
+    // Remove the user from the pool
+    await sut.execute({
+      poolId: pool.id,
+      userIdToRemove: participant.id,
+      creatorId: creator.id,
+    });
+
+    // Check if participant is no longer in the pool
+    participants = await poolsRepository.getPoolParticipants(pool.id);
+    expect(participants).toHaveLength(0);
+  });
+
+  it('should not be able to remove a user if pool is not found', async () => {
+    // Create users
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    const participant = await usersRepository.create({
+      email: 'participant@example.com',
+      fullName: 'Participant User',
+      passwordHash: 'hash',
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: 999,
+        userIdToRemove: participant.id,
+        creatorId: creator.id,
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not be able to remove a user if requester is not the pool creator', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create another user
+    const otherUser = await usersRepository.create({
+      email: 'other@example.com',
+      fullName: 'Other User',
+      passwordHash: 'hash',
+    });
+
+    // Create a participant user
+    const participant = await usersRepository.create({
+      email: 'participant@example.com',
+      fullName: 'Participant User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+    });
+
+    // Add participant to the pool
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: participant.id,
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userIdToRemove: participant.id,
+        creatorId: otherUser.id, // Not the creator
+      })
+    ).rejects.toThrow('Only the pool creator can remove users');
+  });
+
+  it('should not be able to remove a user that does not exist', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userIdToRemove: 'non-existent-user-id',
+        creatorId: creator.id,
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not be able to remove a user that is not a participant', async () => {
+    // Create a tournament
+    const tournament = await tournamentsRepository.create({
+      name: 'Tournament Test',
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    // Create a creator user
+    const creator = await usersRepository.create({
+      email: 'creator@example.com',
+      fullName: 'Creator User',
+      passwordHash: 'hash',
+    });
+
+    // Create a non-participant user
+    const nonParticipant = await usersRepository.create({
+      email: 'nonparticipant@example.com',
+      fullName: 'Non Participant User',
+      passwordHash: 'hash',
+    });
+
+    // Create a pool
+    const pool = await poolsRepository.create({
+      name: 'Test Pool',
+      tournament: {
+        connect: {
+          id: tournament.id,
+        },
+      },
+      creator: {
+        connect: {
+          id: creator.id,
+        },
+      },
+      isPrivate: false,
+    });
+
+    await expect(() =>
+      sut.execute({
+        poolId: pool.id,
+        userIdToRemove: nonParticipant.id,
+        creatorId: creator.id,
+      })
+    ).rejects.toThrow('User is not a participant in this pool');
+  });
+});

--- a/src/useCases/pools/removeUserFromPoolUseCase.ts
+++ b/src/useCases/pools/removeUserFromPoolUseCase.ts
@@ -1,0 +1,51 @@
+import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
+import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
+import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+
+interface IRemoveUserFromPoolRequest {
+  poolId: number;
+  userIdToRemove: string;
+  creatorId: string;
+}
+
+export class RemoveUserFromPoolUseCase {
+  constructor(
+    private poolsRepository: IPoolsRepository,
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute({ poolId, userIdToRemove, creatorId }: IRemoveUserFromPoolRequest) {
+    // Verify pool exists
+    const pool = await this.poolsRepository.findById(poolId);
+    if (!pool) {
+      throw new ResourceNotFoundError('Pool not found');
+    }
+
+    // Verify the requester is the pool creator
+    if (pool.creatorId !== creatorId) {
+      throw new Error('Only the pool creator can remove users');
+    }
+
+    // Verify user to remove exists
+    const userToRemove = await this.usersRepository.findById(userIdToRemove);
+    if (!userToRemove) {
+      throw new ResourceNotFoundError('User to remove not found');
+    }
+
+    // Check if user is a participant
+    const participants = await this.poolsRepository.getPoolParticipants(poolId);
+    const isParticipant = participants.some((participant) => participant.userId === userIdToRemove);
+
+    if (!isParticipant) {
+      throw new Error('User is not a participant in this pool');
+    }
+
+    // Remove user from pool participants
+    await this.poolsRepository.removeParticipant({
+      poolId,
+      userId: userIdToRemove,
+    });
+
+    return pool;
+  }
+}


### PR DESCRIPTION
This commit adds two new API endpoints to manage pool participants:
- `/pools/:poolId/leave` - Allows a user to leave a pool
- `/pools/:poolId/users/:userId` - Allows removal of a specific user from a pool

The implementation includes:
- New controller functions for leaving pools and removing users
- Interface updates to `IPoolsRepository` with a new `removeParticipant` method
- Implementation of `removeParticipant` in both repository classes
- Removal of empty users.ts file