### PR TITLE
:hammer: feat: Implement get match use case and related functionalities

### DIFF
--- a/src/repositories/matches/IMatchesRepository.ts
+++ b/src/repositories/matches/IMatchesRepository.ts
@@ -1,5 +1,4 @@
 import { Match, Prisma } from '@prisma/client';
-
 export interface IMatchesRepository {
   create(data: Prisma.MatchCreateInput): Promise<Match>;
   findById(id: number): Promise<Match | null>;
@@ -7,4 +6,5 @@ export interface IMatchesRepository {
   findUpcomingMatches(tournamentId: number): Promise<Match[]>;
   findCompletedMatches(tournamentId: number): Promise<Match[]>;
   update(id: number, data: Prisma.MatchUpdateInput): Promise<Match>;
+  getMatchWithTeams(id: number): Promise<Match | null>;
 }

--- a/src/repositories/matches/InMemoryMatchesRepository.ts
+++ b/src/repositories/matches/InMemoryMatchesRepository.ts
@@ -1,8 +1,10 @@
-import { Match, MatchStage, MatchStatus, Prisma } from '@prisma/client';
+import { Match, MatchStage, MatchStatus, Prisma, Team, Tournament } from '@prisma/client';
 import { IMatchesRepository } from './IMatchesRepository';
 
 export class InMemoryMatchesRepository implements IMatchesRepository {
   public matches: Match[] = [];
+  public teams: Team[] = [];
+  public tournaments: Tournament[] = [];
 
   async create(data: Prisma.MatchCreateInput): Promise<Match> {
     const newId = this.matches.length + 1;
@@ -105,5 +107,28 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
 
     this.matches[matchIndex] = updatedMatch;
     return updatedMatch;
+  }
+
+  async getMatchWithTeams(id: number): Promise<Match | null> {
+    const match = this.matches.find((match) => match.id === id);
+
+    if (!match) {
+      return null;
+    }
+
+    // In a real implementation, we would need to join with teams
+    // Since this is an in-memory implementation, we'll simulate this by
+    // finding the teams from a teams array that would be part of this repository
+    const homeTeam = this.teams.find((team) => team.id === match.homeTeamId);
+    const awayTeam = this.teams.find((team) => team.id === match.awayTeamId);
+    const tournament = this.tournaments.find((tournament) => tournament.id === match.tournamentId);
+
+    // Create a new object that includes the match and its related entities
+    return {
+      ...match,
+      homeTeam,
+      awayTeam,
+      tournament,
+    } as unknown as Match;
   }
 }

--- a/src/repositories/matches/PrismaMatchesRepository.ts
+++ b/src/repositories/matches/PrismaMatchesRepository.ts
@@ -63,4 +63,17 @@ export class PrismaMatchesRepository implements IMatchesRepository {
 
     return match;
   }
+
+  async getMatchWithTeams(id: number): Promise<Match | null> {
+    const match = await prisma.match.findUnique({
+      where: { id },
+      include: {
+        homeTeam: true,
+        awayTeam: true,
+        tournament: true,
+      },
+    });
+
+    return match;
+  }
 }

--- a/src/useCases/matches/getMatchUseCase.spec.ts
+++ b/src/useCases/matches/getMatchUseCase.spec.ts
@@ -1,0 +1,88 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
+import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
+import { InMemoryTournamentsRepository } from '@/repositories/tournaments/InMemoryTournamentsRepository';
+import { createMatch } from '@/test/mocks/match';
+import { createTeam } from '@/test/mocks/teams';
+import { createTournament } from '@/test/mocks/tournament';
+import { Match, MatchStage, MatchStatus, Team, Tournament } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GetMatchUseCase } from './getMatchUseCase';
+
+// Define an extended Match type that includes the related entities
+type MatchWithRelations = Match & {
+  homeTeam: Team;
+  awayTeam: Team;
+  tournament: Tournament;
+};
+
+describe('Get Match Information Use Case', () => {
+  let matchesRepository: InMemoryMatchesRepository;
+  let tournamentsRepository: InMemoryTournamentsRepository;
+  let teamsRepository: InMemoryTeamsRepository;
+  let sut: GetMatchUseCase;
+
+  let tournament: Tournament;
+  let homeTeam: Team;
+  let awayTeam: Team;
+  let match: Match;
+
+  beforeEach(async () => {
+    matchesRepository = new InMemoryMatchesRepository();
+    tournamentsRepository = new InMemoryTournamentsRepository();
+    teamsRepository = new InMemoryTeamsRepository();
+    sut = new GetMatchUseCase(matchesRepository);
+
+    // Create a tournament
+    tournament = await createTournament(tournamentsRepository, {});
+
+    // Create teams
+    homeTeam = await createTeam(teamsRepository, { name: 'Brazil', countryCode: 'BRA' });
+    awayTeam = await createTeam(teamsRepository, { name: 'Argentina', countryCode: 'ARG' });
+
+    // Create a match
+    match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchStage: MatchStage.GROUP,
+        matchStatus: MatchStatus.SCHEDULED,
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    // Setup the teams and tournaments in the matches repository for the getMatchWithTeams method
+    matchesRepository.teams = teamsRepository.items;
+    matchesRepository.tournaments = tournamentsRepository.tournaments;
+  });
+
+  it('should get match information successfully', async () => {
+    // Execute the use case
+    const result = await sut.execute({ matchId: match.id });
+
+    // Use type assertion to tell TypeScript that result includes related entities
+    const matchWithRelations = result as unknown as MatchWithRelations;
+
+    // Assertions
+    expect(matchWithRelations).toBeTruthy();
+    expect(matchWithRelations.id).toEqual(match.id);
+    expect(matchWithRelations.homeTeam).toBeTruthy();
+    expect(matchWithRelations.homeTeam.id).toEqual(homeTeam.id);
+    expect(matchWithRelations.homeTeam.name).toEqual(homeTeam.name);
+    expect(matchWithRelations.homeTeam.countryCode).toEqual(homeTeam.countryCode);
+    expect(matchWithRelations.awayTeam).toBeTruthy();
+    expect(matchWithRelations.awayTeam.id).toEqual(awayTeam.id);
+    expect(matchWithRelations.awayTeam.name).toEqual(awayTeam.name);
+    expect(matchWithRelations.awayTeam.countryCode).toEqual(awayTeam.countryCode);
+    expect(matchWithRelations.tournament).toBeTruthy();
+    expect(matchWithRelations.tournament.id).toEqual(tournament.id);
+    expect(matchWithRelations.tournament.name).toEqual(tournament.name);
+  });
+
+  it('should throw ResourceNotFoundError when match does not exist', async () => {
+    // Execute the use case with a non-existent match ID
+    await expect(sut.execute({ matchId: 999 })).rejects.toThrow(ResourceNotFoundError);
+    await expect(sut.execute({ matchId: 999 })).rejects.toThrow('Match not found');
+  });
+});

--- a/src/useCases/matches/getMatchUseCase.ts
+++ b/src/useCases/matches/getMatchUseCase.ts
@@ -1,0 +1,22 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
+import { Match } from '@prisma/client';
+
+interface GetMatchRequest {
+  matchId: number;
+}
+
+export class GetMatchUseCase {
+  constructor(private matchesRepository: IMatchesRepository) {}
+
+  async execute({ matchId }: GetMatchRequest): Promise<Match> {
+    // Get match with teams information
+    const match = await this.matchesRepository.getMatchWithTeams(matchId);
+
+    if (!match) {
+      throw new ResourceNotFoundError('Match not found');
+    }
+
+    return match;
+  }
+}


### PR DESCRIPTION
-   Creation of `GetMatchUseCase` to handle the retrieval of match details.
-   Implementation of `getMatchWithTeams` method in `InMemoryMatchesRepository` to simulate the retrieval of related entities.
-   Implementation of `getMatchWithTeams` method in `PrismaMatchesRepository` to retrieve related entities.
-   Addition of tests for the `getMatchUseCase` to ensure correct functionality and error handling.
-   Updated `IMatchesRepository` interface to include the `getMatchWithTeams` method.