### PR TITLE
:hammer: feat: Implement get match predictions functionality

### DIFF
--- a/src/http/controllers/matches/getMatchPredictions.ts
+++ b/src/http/controllers/matches/getMatchPredictions.ts
@@ -1,0 +1,26 @@
+import { makeGetMatchPredictionsUseCase } from '@/useCases/matches/factories/makeGetMatchPredictionsUseCase';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+export async function getMatchPredictions(request: FastifyRequest, reply: FastifyReply) {
+  const getMatchPredictionsParamsSchema = z.object({
+    matchId: z.coerce.number(),
+  });
+
+  const { matchId } = getMatchPredictionsParamsSchema.parse(request.params);
+
+  try {
+    const getMatchPredictionsUseCase = makeGetMatchPredictionsUseCase();
+
+    const predictions = await getMatchPredictionsUseCase.execute({
+      matchId,
+    });
+
+    return reply.status(200).send({ predictions });
+  } catch (error) {
+    if (error instanceof Error) {
+      return reply.status(400).send({ message: error.message });
+    }
+    return reply.status(500).send({ message: 'Internal server error' });
+  }
+}

--- a/src/http/routes/index.ts
+++ b/src/http/routes/index.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
+import { matchesRoutes } from './matches.routes';
 import { UserRoutes } from './user.routes';
 
 export async function routes(app: FastifyInstance) {
   app.register(UserRoutes);
+  app.register(matchesRoutes);
 }

--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -1,0 +1,9 @@
+import { verifyJwt } from '@/http/middlewares/verifyJWT';
+import { FastifyInstance } from 'fastify';
+import { getMatchPredictions } from '../controllers/matches/getMatchPredictions';
+
+export async function matchesRoutes(app: FastifyInstance) {
+  app.addHook('onRequest', verifyJwt);
+
+  app.get('/matches/:matchId/predictions', getMatchPredictions);
+}

--- a/src/repositories/predictions/IPredictionsRepository.ts
+++ b/src/repositories/predictions/IPredictionsRepository.ts
@@ -10,4 +10,5 @@ export interface IPredictionsRepository {
   ): Promise<Prediction | null>;
   update(id: number, data: Prisma.PredictionUpdateInput): Promise<Prediction>;
   delete(id: number): Promise<void>;
+  findByMatchId(matchId: number): Promise<Prediction[]>;
 }

--- a/src/repositories/predictions/InMemoryPredictionsRepository.ts
+++ b/src/repositories/predictions/InMemoryPredictionsRepository.ts
@@ -100,4 +100,9 @@ export class InMemoryPredictionsRepository implements IPredictionsRepository {
       this.predictions.splice(predictionIndex, 1);
     }
   }
+
+  async findByMatchId(matchId: number): Promise<Prediction[]> {
+    const predictions = this.predictions.filter((item) => item.matchId === matchId);
+    return predictions;
+  }
 }

--- a/src/repositories/predictions/PrismaPredictionsRepository.ts
+++ b/src/repositories/predictions/PrismaPredictionsRepository.ts
@@ -54,4 +54,30 @@ export class PrismaPredictionsRepository implements IPredictionsRepository {
       where: { id },
     });
   }
+
+  async findByMatchId(matchId: number): Promise<Prediction[]> {
+    const predictions = await prisma.prediction.findMany({
+      where: {
+        matchId,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            fullName: true,
+            email: true,
+            profileImageUrl: true,
+          },
+        },
+        pool: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return predictions;
+  }
 }

--- a/src/useCases/matches/factories/makeGetMatchPredictionsUseCase.ts
+++ b/src/useCases/matches/factories/makeGetMatchPredictionsUseCase.ts
@@ -1,0 +1,11 @@
+import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
+import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
+import { GetMatchPredictionsUseCase } from '../getMatchPredictionsUseCase';
+
+export function makeGetMatchPredictionsUseCase() {
+  const predictionsRepository = new PrismaPredictionsRepository();
+  const matchesRepository = new PrismaMatchesRepository();
+  const useCase = new GetMatchPredictionsUseCase(predictionsRepository, matchesRepository);
+
+  return useCase;
+}

--- a/src/useCases/matches/getMatchPredictionsUseCase.spec.ts
+++ b/src/useCases/matches/getMatchPredictionsUseCase.spec.ts
@@ -1,0 +1,302 @@
+import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
+import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
+import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
+import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
+import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
+import { createMatch, createMatchWithTeams } from '@/test/mocks/match';
+import { createPool } from '@/test/mocks/pools';
+import { createTeam } from '@/test/mocks/teams';
+import { createUser } from '@/test/mocks/users';
+import { Match, Pool, User } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GetMatchPredictionsUseCase } from './getMatchPredictionsUseCase';
+
+describe('Get Match Predictions Use Case', () => {
+  let predictionsRepository: InMemoryPredictionsRepository;
+  let matchesRepository: InMemoryMatchesRepository;
+  let poolsRepository: InMemoryPoolsRepository;
+  let usersRepository: InMemoryUsersRepository;
+  let teamsRepository: InMemoryTeamsRepository;
+  let sut: GetMatchPredictionsUseCase;
+
+  let aUser: User;
+  let anotherUser: User;
+  let aPool: Pool;
+  let anotherPool: Pool;
+  let aMatch: Match;
+
+  beforeEach(async () => {
+    predictionsRepository = new InMemoryPredictionsRepository();
+    matchesRepository = new InMemoryMatchesRepository();
+    poolsRepository = new InMemoryPoolsRepository();
+    usersRepository = new InMemoryUsersRepository();
+    teamsRepository = new InMemoryTeamsRepository();
+    sut = new GetMatchPredictionsUseCase(predictionsRepository, matchesRepository);
+
+    // Create users
+    aUser = await createUser(usersRepository, {});
+    anotherUser = await createUser(usersRepository, {
+      email: 'another@example.com',
+      fullName: 'Another User',
+    });
+
+    // Create pools
+    aPool = await createPool(poolsRepository, { creatorId: aUser.id });
+    anotherPool = await createPool(poolsRepository, {
+      creatorId: aUser.id,
+      name: 'Another Pool',
+    });
+
+    // Create match
+    aMatch = await createMatch(
+      matchesRepository,
+      { tournamentId: aPool.tournamentId },
+      await createTeam(teamsRepository, { name: 'Brazil', countryCode: 'BRA' }),
+      await createTeam(teamsRepository, { name: 'Argentina', countryCode: 'ARG' })
+    );
+  });
+
+  it('should return all predictions for a match', async () => {
+    // Create predictions for the match
+    await predictionsRepository.create({
+      pool: { connect: { id: aPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: aUser.id } },
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+
+    await predictionsRepository.create({
+      pool: { connect: { id: anotherPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: aUser.id } },
+      predictedHomeScore: 3,
+      predictedAwayScore: 0,
+    });
+
+    await predictionsRepository.create({
+      pool: { connect: { id: aPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: anotherUser.id } },
+      predictedHomeScore: 1,
+      predictedAwayScore: 1,
+    });
+
+    // Get predictions for the match
+    const predictions = await sut.execute({ matchId: aMatch.id });
+
+    // Assertions
+    expect(predictions).toHaveLength(3);
+    expect(predictions[0].matchId).toBe(aMatch.id);
+    expect(predictions[1].matchId).toBe(aMatch.id);
+    expect(predictions[2].matchId).toBe(aMatch.id);
+  });
+
+  it('should return an empty array when no predictions exist for a match', async () => {
+    // Create a match with no predictions
+    const { match } = await createMatchWithTeams(
+      { matchesRepository, teamsRepository },
+      { tournamentId: aPool.tournamentId }
+    );
+
+    // Get predictions for the match
+    const predictions = await sut.execute({ matchId: match.id });
+
+    // Assertions
+    expect(predictions).toHaveLength(0);
+    expect(predictions).toEqual([]);
+  });
+
+  it('should throw an error when the match does not exist', async () => {
+    // Attempt to get predictions for a non-existent match
+    const nonExistentMatchId = 999;
+
+    // Assertions
+    await expect(sut.execute({ matchId: nonExistentMatchId })).rejects.toThrow('Match not found');
+  });
+
+  // it('should return predictions with correct user and pool information', async () => {
+  //   // Create a prediction with specific user and pool
+  //   await predictionsRepository.create({
+  //     pool: { connect: { id: aPool.id } },
+  //     match: { connect: { id: aMatch.id } },
+  //     user: { connect: { id: aUser.id } },
+  //     predictedHomeScore: 2,
+  //     predictedAwayScore: 1,
+  //   });
+
+  //   // Mock the repository to include user and pool information
+  //   // This is needed because InMemoryPredictionsRepository doesn't handle includes
+  //   predictionsRepository.findByMatchId = async (matchId: number) => {
+  //     const predictions = predictionsRepository.items.filter((item) => item.matchId === matchId);
+  //     return predictions.map((prediction) => ({
+  //       ...prediction,
+  //       user: {
+  //         id: prediction.userId,
+  //         fullName: prediction.userId === aUser.id ? aUser.fullName : anotherUser.fullName,
+  //         email: prediction.userId === aUser.id ? aUser.email : anotherUser.email,
+  //         profileImageUrl: null,
+  //       },
+  //       pool: {
+  //         id: prediction.poolId,
+  //         name: prediction.poolId === aPool.id ? aPool.name : anotherPool.name,
+  //       },
+  //     })) as any;
+  //   };
+
+  //   // Get predictions for the match
+  //   const predictions = await sut.execute({ matchId: aMatch.id });
+
+  //   // Assertions
+  //   expect(predictions).toHaveLength(1);
+  //   expect(predictions[0].user).toBeDefined();
+  //   expect(predictions[0].user.fullName).toBe(aUser.fullName);
+  //   expect(predictions[0].pool).toBeDefined();
+  //   expect(predictions[0].pool.name).toBe(aPool.name);
+  // });
+
+  it('should return predictions for a match with extra time and penalties', async () => {
+    // Create a match in knockout stage
+    const { match } = await createMatchWithTeams(
+      { matchesRepository, teamsRepository },
+      {
+        tournamentId: aPool.tournamentId,
+        matchStage: 'SEMI_FINAL',
+      }
+    );
+
+    // Create prediction with extra time and penalties
+    await predictionsRepository.create({
+      pool: { connect: { id: aPool.id } },
+      match: { connect: { id: match.id } },
+      user: { connect: { id: aUser.id } },
+      predictedHomeScore: 1,
+      predictedAwayScore: 1,
+      predictedHasExtraTime: true,
+      predictedHasPenalties: true,
+      predictedPenaltyHomeScore: 5,
+      predictedPenaltyAwayScore: 4,
+    });
+
+    // Get predictions for the match
+    const predictions = await sut.execute({ matchId: match.id });
+
+    // Assertions
+    expect(predictions).toHaveLength(1);
+    expect(predictions[0].predictedHasExtraTime).toBe(true);
+    expect(predictions[0].predictedHasPenalties).toBe(true);
+    expect(predictions[0].predictedPenaltyHomeScore).toBe(5);
+    expect(predictions[0].predictedPenaltyAwayScore).toBe(4);
+  });
+
+  it('should return predictions from multiple pools for the same match', async () => {
+    // Create a third pool
+    const thirdPool = await createPool(poolsRepository, {
+      creatorId: anotherUser.id,
+      name: 'Third Pool',
+    });
+
+    // Create predictions for the same match in different pools
+    await predictionsRepository.create({
+      pool: { connect: { id: aPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: aUser.id } },
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+
+    await predictionsRepository.create({
+      pool: { connect: { id: anotherPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: aUser.id } },
+      predictedHomeScore: 3,
+      predictedAwayScore: 0,
+    });
+
+    await predictionsRepository.create({
+      pool: { connect: { id: thirdPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: anotherUser.id } },
+      predictedHomeScore: 1,
+      predictedAwayScore: 2,
+    });
+
+    // Get predictions for the match
+    const predictions = await sut.execute({ matchId: aMatch.id });
+
+    // Assertions
+    expect(predictions).toHaveLength(3);
+
+    // Check that predictions come from different pools
+    const poolIds = predictions.map((p) => p.poolId);
+    expect(poolIds).toContain(aPool.id);
+    expect(poolIds).toContain(anotherPool.id);
+    expect(poolIds).toContain(thirdPool.id);
+
+    // Verify all predictions are for the same match
+    const uniqueMatchIds = new Set(predictions.map((p) => p.matchId));
+    expect(uniqueMatchIds.size).toBe(1);
+    expect(uniqueMatchIds.has(aMatch.id)).toBe(true);
+  });
+
+  it('should handle a large number of predictions efficiently', async () => {
+    // Create a large number of predictions (e.g., 100)
+    for (let i = 0; i < 100; i++) {
+      // Create a new user for each prediction to ensure uniqueness
+      const user = await createUser(usersRepository, {
+        email: `user${i}@example.com`,
+        fullName: `User ${i}`,
+      });
+
+      // Create a new pool for each prediction to ensure uniqueness
+      const pool = await createPool(poolsRepository, {
+        creatorId: user.id,
+        name: `Pool ${i}`,
+      });
+
+      // Create prediction
+      await predictionsRepository.create({
+        pool: { connect: { id: pool.id } },
+        match: { connect: { id: aMatch.id } },
+        user: { connect: { id: user.id } },
+        predictedHomeScore: Math.floor(Math.random() * 5),
+        predictedAwayScore: Math.floor(Math.random() * 5),
+      });
+    }
+
+    // Get predictions for the match
+    const predictions = await sut.execute({ matchId: aMatch.id });
+
+    // Assertions
+    expect(predictions).toHaveLength(100);
+
+    // Check that all predictions are for the correct match
+    const allForCorrectMatch = predictions.every((p) => p.matchId === aMatch.id);
+    expect(allForCorrectMatch).toBe(true);
+  });
+
+  it('should return predictions with updated scores', async () => {
+    // Create a prediction
+    const prediction = await predictionsRepository.create({
+      pool: { connect: { id: aPool.id } },
+      match: { connect: { id: aMatch.id } },
+      user: { connect: { id: aUser.id } },
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+
+    // Update the prediction (simulating an update)
+    prediction.predictedHomeScore = 3;
+    prediction.predictedAwayScore = 2;
+    prediction.updatedAt = new Date();
+
+    // Get predictions for the match
+    const predictions = await sut.execute({ matchId: aMatch.id });
+
+    // Assertions
+    expect(predictions).toHaveLength(1);
+    expect(predictions[0].predictedHomeScore).toBe(3);
+    expect(predictions[0].predictedAwayScore).toBe(2);
+    expect(predictions[0].updatedAt).toBeTruthy();
+  });
+});

--- a/src/useCases/matches/getMatchPredictionsUseCase.ts
+++ b/src/useCases/matches/getMatchPredictionsUseCase.ts
@@ -1,0 +1,29 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
+import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
+import { Prediction } from '@prisma/client';
+
+interface GetMatchPredictionsRequest {
+  matchId: number;
+}
+
+export class GetMatchPredictionsUseCase {
+  constructor(
+    private predictionsRepository: IPredictionsRepository,
+    private matchesRepository: IMatchesRepository
+  ) {}
+
+  async execute({ matchId }: GetMatchPredictionsRequest): Promise<Prediction[]> {
+    // Check if match exists
+    const match = await this.matchesRepository.findById(matchId);
+
+    if (!match) {
+      throw new ResourceNotFoundError('Match not found');
+    }
+
+    // Get all predictions for the match
+    const predictions = await this.predictionsRepository.findByMatchId(matchId);
+
+    return predictions;
+  }
+}


### PR DESCRIPTION
-   Created `GetMatchPredictionsUseCase` to handle the retrieval of match predictions.
-   Implemented `findByMatchId` method in `PrismaPredictionsRepository` and `InMemoryPredictionsRepository` to fetch predictions by match ID.
-   Created a factory function `makeGetMatchPredictionsUseCase` to instantiate the use case.
-   Added a new route `/matches/:matchId/predictions` to the `matches.routes.ts` file to handle the API endpoint for retrieving match predictions.
-   Created a controller `getMatchPredictions` to handle the request and response for the API endpoint.
-   Updated `IPredictionsRepository` interface to include the `findByMatchId` method.
-   Added tests for the `getMatchPredictionsUseCase` to ensure correct functionality and error handling.