### PR TITLE
:sparkles: feat: Implement get prediction use case

### DIFF
--- a/src/test/mocks/predictions.ts
+++ b/src/test/mocks/predictions.ts
@@ -1,0 +1,47 @@
+import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
+import { Prediction } from '@prisma/client';
+
+export async function createPrediction(
+  repository: IPredictionsRepository,
+  data: {
+    matchId?: number;
+    poolId?: number;
+    userId?: string;
+    predictedHomeScore?: number;
+    predictedAwayScore?: number;
+    hasExtraTime?: boolean;
+    hasPenalties?: boolean;
+    penaltyHomeScore?: number;
+    penaltyAwayScore?: number;
+  }
+): Promise<Prediction> {
+  const randomPredictionNumber = Math.floor(Math.random() * 100);
+  const homeRandomNumber = Math.floor(Math.random() * 10);
+  const awayRandomNumber = Math.floor(Math.random() * 10);
+
+  const prediction = await repository.create({
+    match: {
+      connect: {
+        id: data.matchId ?? randomPredictionNumber,
+      },
+    },
+    pool: {
+      connect: {
+        id: data.poolId ?? randomPredictionNumber,
+      },
+    },
+    user: {
+      connect: {
+        id: data.userId ?? `user-${randomPredictionNumber}`,
+      },
+    },
+    predictedHomeScore: data.predictedHomeScore ?? randomPredictionNumber,
+    predictedAwayScore: data.predictedAwayScore ?? randomPredictionNumber,
+    predictedHasExtraTime: data.hasExtraTime ?? false,
+    predictedHasPenalties: data.hasPenalties ?? false,
+    predictedPenaltyHomeScore: data.penaltyHomeScore ?? homeRandomNumber,
+    predictedPenaltyAwayScore: data.penaltyAwayScore ?? awayRandomNumber,
+  });
+
+  return prediction;
+}

--- a/src/useCases/predictions/factories/makeGetPredictionUseCase.ts
+++ b/src/useCases/predictions/factories/makeGetPredictionUseCase.ts
@@ -1,0 +1,9 @@
+import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
+import { GetPredictionUseCase } from '../getPredictionUseCase';
+
+export function makeGetPredictionUseCase() {
+  const predictionsRepository = new PrismaPredictionsRepository();
+  const useCase = new GetPredictionUseCase(predictionsRepository);
+
+  return useCase;
+}

--- a/src/useCases/predictions/getPredictionUseCase.spec.ts
+++ b/src/useCases/predictions/getPredictionUseCase.spec.ts
@@ -1,0 +1,53 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
+import { createPrediction } from '@/test/mocks/predictions';
+import { Prediction } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GetPredictionUseCase } from './getPredictionUseCase';
+
+describe('Get Prediction Use Case', () => {
+  let predictionsRepository: InMemoryPredictionsRepository;
+  let sut: GetPredictionUseCase;
+  let prediction: Prediction;
+
+  beforeEach(async () => {
+    predictionsRepository = new InMemoryPredictionsRepository();
+    sut = new GetPredictionUseCase(predictionsRepository);
+
+    // Create a mock prediction
+    prediction = await createPrediction(predictionsRepository, {
+      userId: 'user-01',
+      matchId: 1,
+      poolId: 1,
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+  });
+
+  it('should be able to get a prediction by id', async () => {
+    const result = await sut.execute({
+      predictionId: 1,
+      userId: 'user-01',
+    });
+
+    expect(result).toEqual(prediction);
+  });
+
+  it('should not be able to get a non-existent prediction', async () => {
+    await expect(() =>
+      sut.execute({
+        predictionId: 999,
+        userId: 'user-01',
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+
+  it('should not be able to get a prediction from another user', async () => {
+    await expect(() =>
+      sut.execute({
+        predictionId: 1,
+        userId: 'user-02',
+      })
+    ).rejects.toThrowError('You can only access your own predictions');
+  });
+});

--- a/src/useCases/predictions/getPredictionUseCase.ts
+++ b/src/useCases/predictions/getPredictionUseCase.ts
@@ -1,0 +1,28 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
+import { Prediction } from '@prisma/client';
+
+interface GetPredictionUseCaseRequest {
+  predictionId: number;
+  userId: string;
+}
+
+export class GetPredictionUseCase {
+  constructor(private predictionsRepository: IPredictionsRepository) {}
+
+  async execute({ predictionId, userId }: GetPredictionUseCaseRequest): Promise<Prediction> {
+    // Check if prediction exists
+    const prediction = await this.predictionsRepository.findById(predictionId);
+
+    if (!prediction) {
+      throw new ResourceNotFoundError('Prediction not found');
+    }
+
+    // Verify that the prediction belongs to the user
+    if (prediction.userId !== userId) {
+      throw new Error('You can only access your own predictions');
+    }
+
+    return prediction;
+  }
+}


### PR DESCRIPTION
- Created `GetPredictionUseCase` to handle the retrieval of a specific prediction.
- Implemented `findById` method in `PrismaPredictionsRepository` to fetch a prediction by ID.
- Created a factory function `makeGetPredictionUseCase` to instantiate the use case.
- Added tests for the `GetPredictionUseCase` to ensure correct functionality and error handling, including checks for non-existent predictions and access restrictions.
- Added a mock function `createPrediction` to assist with test setup.