### PR TITLE
:sparkles: feat: Implement get user predictions functionality

### DIFF
--- a/src/repositories/predictions/IPredictionsRepository.ts
+++ b/src/repositories/predictions/IPredictionsRepository.ts
@@ -11,4 +11,5 @@ export interface IPredictionsRepository {
   update(id: number, data: Prisma.PredictionUpdateInput): Promise<Prediction>;
   delete(id: number): Promise<void>;
   findByMatchId(matchId: number): Promise<Prediction[]>;
+  findByUserId(userId: string, poolId?: number): Promise<Prediction[]>;
 }

--- a/src/repositories/predictions/InMemoryPredictionsRepository.ts
+++ b/src/repositories/predictions/InMemoryPredictionsRepository.ts
@@ -105,4 +105,14 @@ export class InMemoryPredictionsRepository implements IPredictionsRepository {
     const predictions = this.predictions.filter((item) => item.matchId === matchId);
     return predictions;
   }
+
+  async findByUserId(userId: string, poolId?: number): Promise<Prediction[]> {
+    let predictions = this.predictions.filter((prediction) => prediction.userId === userId);
+
+    if (poolId) {
+      predictions = predictions.filter((prediction) => prediction.poolId === poolId);
+    }
+
+    return predictions;
+  }
 }

--- a/src/repositories/predictions/PrismaPredictionsRepository.ts
+++ b/src/repositories/predictions/PrismaPredictionsRepository.ts
@@ -80,4 +80,23 @@ export class PrismaPredictionsRepository implements IPredictionsRepository {
 
     return predictions;
   }
+
+  async findByUserId(userId: string, poolId?: number): Promise<Prediction[]> {
+    const whereClause: Prisma.PredictionWhereInput = {
+      userId,
+    };
+
+    if (poolId) {
+      whereClause.poolId = poolId;
+    }
+
+    const predictions = await prisma.prediction.findMany({
+      where: whereClause,
+      orderBy: {
+        submittedAt: 'desc',
+      },
+    });
+
+    return predictions;
+  }
 }

--- a/src/useCases/users/factory/makeGetUserPredictionsUseCase.ts
+++ b/src/useCases/users/factory/makeGetUserPredictionsUseCase.ts
@@ -1,0 +1,14 @@
+import { PrismaPredictionsRepository } from '../../../repositories/predictions/PrismaPredictionsRepository';
+import { PrismaUsersRepository } from '../../../repositories/users/PrismaUsersRepository';
+import { GetUserPredictionsUseCase } from '../getUserPredictionsUseCase';
+
+export function makeGetUserPredictionsUseCase() {
+  const predictionsRepository = new PrismaPredictionsRepository();
+  const usersRepository = new PrismaUsersRepository();
+  const getUserPredictionsUseCase = new GetUserPredictionsUseCase(
+    predictionsRepository,
+    usersRepository
+  );
+
+  return getUserPredictionsUseCase;
+}

--- a/src/useCases/users/getUserPredictionsUseCase.spec.ts
+++ b/src/useCases/users/getUserPredictionsUseCase.spec.ts
@@ -1,0 +1,153 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
+import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
+import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
+import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
+import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
+import { createMatch } from '@/test/mocks/match';
+import { createPool } from '@/test/mocks/pools';
+import { createPrediction } from '@/test/mocks/predictions';
+import { createTeam } from '@/test/mocks/teams';
+import { createUser } from '@/test/mocks/users';
+import { Match, Pool, Prediction, User } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GetUserPredictionsUseCase } from './getUserPredictionsUseCase';
+
+describe('Get User Predictions Use Case', () => {
+  let predictionsRepository: InMemoryPredictionsRepository;
+  let usersRepository: InMemoryUsersRepository;
+  let poolsRepository: InMemoryPoolsRepository;
+  let teamsRepository: InMemoryTeamsRepository;
+  let matchesRepository: InMemoryMatchesRepository;
+  let sut: GetUserPredictionsUseCase;
+
+  let user1: User;
+  let user2: User;
+  let pool1: Pool;
+  let pool2: Pool;
+  let match1: Match;
+  let match2: Match;
+  let prediction1: Prediction;
+  let prediction2: Prediction;
+  let prediction3: Prediction;
+
+  beforeEach(async () => {
+    predictionsRepository = new InMemoryPredictionsRepository();
+    usersRepository = new InMemoryUsersRepository();
+    poolsRepository = new InMemoryPoolsRepository();
+    teamsRepository = new InMemoryTeamsRepository();
+    matchesRepository = new InMemoryMatchesRepository();
+
+    sut = new GetUserPredictionsUseCase(predictionsRepository, usersRepository);
+
+    // Create test users
+    user1 = await createUser(usersRepository, { fullName: 'User One' });
+    user2 = await createUser(usersRepository, { fullName: 'User Two' });
+
+    // Create test pools
+    pool1 = await createPool(poolsRepository, { creatorId: user1.id, name: 'Pool One' });
+    pool2 = await createPool(poolsRepository, { creatorId: user1.id, name: 'Pool Two' });
+
+    // Create test matches
+    match1 = await createMatch(
+      matchesRepository,
+      { tournamentId: pool1.tournamentId },
+      await createTeam(teamsRepository, { name: 'Brazil', countryCode: 'BRA' }),
+      await createTeam(teamsRepository, { name: 'Argentina', countryCode: 'ARG' })
+    );
+
+    match2 = await createMatch(
+      matchesRepository,
+      { tournamentId: pool1.tournamentId },
+      await createTeam(teamsRepository, { name: 'France', countryCode: 'FRA' }),
+      await createTeam(teamsRepository, { name: 'Germany', countryCode: 'GER' })
+    );
+
+    // Create test predictions
+    prediction1 = await createPrediction(predictionsRepository, {
+      userId: user1.id,
+      matchId: match1.id,
+      poolId: pool1.id,
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+
+    prediction2 = await createPrediction(predictionsRepository, {
+      userId: user1.id,
+      matchId: match2.id,
+      poolId: pool1.id,
+      predictedHomeScore: 1,
+      predictedAwayScore: 1,
+    });
+
+    prediction3 = await createPrediction(predictionsRepository, {
+      userId: user1.id,
+      matchId: match1.id,
+      poolId: pool2.id,
+      predictedHomeScore: 3,
+      predictedAwayScore: 0,
+    });
+
+    // Create a prediction for user2
+    await createPrediction(predictionsRepository, {
+      userId: user2.id,
+      matchId: match1.id,
+      poolId: pool1.id,
+      predictedHomeScore: 0,
+      predictedAwayScore: 2,
+    });
+  });
+
+  it('should be able to get all predictions for a user', async () => {
+    const result = await sut.execute({
+      userId: user1.id,
+    });
+
+    expect(result.predictions).toHaveLength(3);
+    expect(result.predictions).toEqual(
+      expect.arrayContaining([prediction1, prediction2, prediction3])
+    );
+  });
+
+  it('should be able to get predictions for a user filtered by pool', async () => {
+    const result = await sut.execute({
+      userId: user1.id,
+      poolId: pool1.id,
+    });
+
+    expect(result.predictions).toHaveLength(2);
+    expect(result.predictions).toEqual(expect.arrayContaining([prediction1, prediction2]));
+  });
+
+  it('should return empty array when user has no predictions', async () => {
+    const newUser = await createUser(usersRepository, { fullName: 'New User' });
+
+    const result = await sut.execute({
+      userId: newUser.id,
+    });
+
+    expect(result.predictions).toHaveLength(0);
+    expect(result.predictions).toEqual([]);
+  });
+
+  it('should not return predictions from other users', async () => {
+    const result = await sut.execute({
+      userId: user1.id,
+    });
+
+    // Make sure we don't get user2's prediction
+    const hasUser2Predictions = result.predictions.some(
+      (prediction) => prediction.userId === user2.id
+    );
+
+    expect(hasUser2Predictions).toBe(false);
+  });
+
+  it('should throw an error if user does not exist', async () => {
+    await expect(() =>
+      sut.execute({
+        userId: 'non-existent-user',
+      })
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+  });
+});

--- a/src/useCases/users/getUserPredictionsUseCase.ts
+++ b/src/useCases/users/getUserPredictionsUseCase.ts
@@ -1,0 +1,39 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { Prediction } from '@prisma/client';
+
+interface GetUserPredictionsUseCaseRequest {
+  userId: string;
+  poolId?: number;
+}
+
+interface GetUserPredictionsUseCaseResponse {
+  predictions: Prediction[];
+}
+
+export class GetUserPredictionsUseCase {
+  constructor(
+    private predictionsRepository: IPredictionsRepository,
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute({
+    userId,
+    poolId,
+  }: GetUserPredictionsUseCaseRequest): Promise<GetUserPredictionsUseCaseResponse> {
+    // Check if user exists
+    const user = await this.usersRepository.findById(userId);
+
+    if (!user) {
+      throw new ResourceNotFoundError('User not found');
+    }
+
+    // Get all predictions for the user, optionally filtered by pool
+    const predictions = await this.predictionsRepository.findByUserId(userId, poolId);
+
+    return {
+      predictions,
+    };
+  }
+}


### PR DESCRIPTION
- Implemented `findByUserId` method in `IPredictionsRepository`, `PrismaPredictionsRepository`, and `InMemoryPredictionsRepository` to fetch predictions by user ID, optionally filtered by pool ID.
- Created `GetUserPredictionsUseCase` to handle the retrieval of user predictions.
- Created a factory function `makeGetUserPredictionsUseCase` to instantiate the use case.
- Added tests for the `GetUserPredictionsUseCase` to ensure correct functionality, including checks for filtering by pool and handling non-existent users.