### PR TITLE
:sparkles: feat: Implement join pool functionality

### DIFF
--- a/src/http/controllers/pools/joinPoolController.spec.ts
+++ b/src/http/controllers/pools/joinPoolController.spec.ts
@@ -1,0 +1,178 @@
+import { createServer } from '@/app';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createPool } from '@/test/mocks/pools';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('Join Pool Controller (e2e)', async () => {
+  const app = await createServer();
+  let userId: string;
+  let token: string;
+
+  let usersRepository: IUsersRepository;
+  let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+
+  beforeAll(async () => {
+    await app.ready();
+    ({ token, userId } = await getSupabaseAccessToken(app));
+    usersRepository = new PrismaUsersRepository();
+    poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should be able to join a pool by poolId', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    const response = await request(app.server)
+      .post('/pools/join')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        poolId: pool.id,
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pool');
+    expect(response.body.pool).toEqual(
+      expect.objectContaining({
+        id: pool.id,
+        name: pool.name,
+        isPrivate: pool.isPrivate,
+      })
+    );
+  });
+
+  it('should be able to join a pool by inviteCode', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'private-pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+      isPrivate: true,
+    });
+
+    const response = await request(app.server)
+      .post('/pools/join')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        inviteCode: pool.inviteCode,
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pool');
+    expect(response.body.pool).toEqual(
+      expect.objectContaining({
+        id: pool.id,
+        name: pool.name,
+        isPrivate: pool.isPrivate,
+      })
+    );
+  });
+
+  it('should return 404 when trying to join a pool that does not exist', async () => {
+    const nonExistentPoolId = 9999;
+
+    const response = await request(app.server)
+      .post('/pools/join')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        poolId: nonExistentPoolId,
+      });
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should return 404 when trying to join a pool with invalid invite code', async () => {
+    const response = await request(app.server)
+      .post('/pools/join')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        inviteCode: 'invalid-invite-code',
+      });
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should return 422 when neither poolId nor inviteCode is provided', async () => {
+    const response = await request(app.server)
+      .post('/pools/join')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(response.statusCode).toEqual(422);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should return 401 when user is already a participant in the pool', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'already-joined-pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+    });
+
+    // Join the pool first time
+    await request(app.server).post('/pools/join').set('Authorization', `Bearer ${token}`).send({
+      poolId: pool.id,
+    });
+
+    // Try to join again
+    const response = await request(app.server)
+      .post('/pools/join')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        poolId: pool.id,
+      });
+
+    expect(response.statusCode).toEqual(401);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('already a participant');
+  });
+
+  it('should require authentication', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'auth-test-pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+    });
+
+    const response = await request(app.server).post('/pools/join').send({
+      poolId: pool.id,
+    });
+
+    expect(response.statusCode).toEqual(401);
+  });
+});

--- a/src/http/controllers/pools/joinPoolController.ts
+++ b/src/http/controllers/pools/joinPoolController.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { UnauthorizedError } from '@/useCases/pools/errors/UnauthorizedError';
 import { makeJoinPoolUseCase } from '@/useCases/pools/factory/makeJoinPoolUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
@@ -32,8 +34,14 @@ export async function JoinPoolController(request: FastifyRequest, reply: Fastify
       },
     });
   } catch (error) {
-    if (error instanceof Error) {
-      return reply.status(400).send({ message: error.message });
+    if (error instanceof ResourceNotFoundError) {
+      return reply.status(404).send({ message: error.message });
+    }
+    if (error instanceof UnauthorizedError) {
+      return reply.status(401).send({ message: error.message });
+    }
+    if (error instanceof z.ZodError) {
+      return reply.status(422).send({ message: error.message });
     }
 
     throw error;

--- a/src/test/mocks/pools.ts
+++ b/src/test/mocks/pools.ts
@@ -11,6 +11,7 @@ export async function createPool(
     tournamentId?: number;
     creatorId?: string;
     isPrivate?: boolean;
+    inviteCode?: string;
   }
 ): Promise<Pool> {
   const randomPoolNumber = Math.floor(Math.random() * 100);
@@ -19,6 +20,7 @@ export async function createPool(
     name: data.name ?? `Pool ${randomPoolNumber}`,
     tournament: { connect: { id: data.tournamentId ?? randomPoolNumber } },
     creator: { connect: { id: data.creatorId ?? `faker-${randomPoolNumber}` } },
+    inviteCode: data.inviteCode ?? `invite-${randomPoolNumber}`,
   });
 
   await repository.addParticipant({

--- a/src/useCases/pools/errors/UnauthorizedError.ts
+++ b/src/useCases/pools/errors/UnauthorizedError.ts
@@ -1,0 +1,7 @@
+export class UnauthorizedError extends Error {
+  constructor(info: string) {
+    super(`Unauthorized: ${info}`);
+    this.name = 'UnauthorizedError';
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
+  }
+}

--- a/src/useCases/pools/joinPoolUseCase.ts
+++ b/src/useCases/pools/joinPoolUseCase.ts
@@ -1,6 +1,7 @@
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
 import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+import { UnauthorizedError } from './errors/UnauthorizedError';
 
 interface IJoinPoolRequest {
   poolId?: number;
@@ -29,7 +30,7 @@ export class JoinPoolUseCase {
     } else if (inviteCode) {
       pool = await this.poolsRepository.findByInviteCode(inviteCode);
     } else {
-      throw new Error('Either poolId or inviteCode must be provided');
+      throw new ResourceNotFoundError('Either poolId or inviteCode must be provided');
     }
 
     if (!pool) {
@@ -38,11 +39,11 @@ export class JoinPoolUseCase {
 
     // Check if pool is private and user has the correct invite code
     if (pool.isPrivate && !inviteCode) {
-      throw new Error('This pool is private and requires an invite code');
+      throw new UnauthorizedError('This pool is private and requires an invite code');
     }
 
     if (pool.isPrivate && inviteCode !== pool.inviteCode) {
-      throw new Error('Invalid invite code');
+      throw new UnauthorizedError('Invalid invite code');
     }
 
     // Check if pool has a maximum number of participants
@@ -63,7 +64,7 @@ export class JoinPoolUseCase {
     const isAlreadyParticipant = participants.some((participant) => participant.userId === userId);
 
     if (isAlreadyParticipant) {
-      throw new Error('User is already a participant in this pool');
+      throw new UnauthorizedError('User is already a participant in this pool');
     }
 
     // Add user as participant


### PR DESCRIPTION
- Added `UnauthorizedError` to handle unauthorized access attempts.
- Added `inviteCode` to `createPool` mock and `Pool` model.
- Updated `joinPoolController` to handle `ResourceNotFoundError`, `UnauthorizedError`, and Zod validation errors, returning appropriate HTTP status codes (404, 401, and 422 respectively).
- Modified `joinPoolUseCase` to use `ResourceNotFoundError` when pool or invite code is not provided and `UnauthorizedError` for private pool access issues and already a participant.
- Added e2e tests for the `joinPoolController`, including tests for successful joins by poolId and inviteCode, handling non-existent pools, invalid invite codes, validation errors, and already joined users, and authentication requirements.