### PR TITLE
:hammer: feat: Improve leave pool functionality

### DIFF
--- a/src/http/controllers/pools/leavePoolController.spec.ts
+++ b/src/http/controllers/pools/leavePoolController.spec.ts
@@ -1,0 +1,129 @@
+import { createServer } from '@/app';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createPool } from '@/test/mocks/pools';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('Leave Pool Controller (e2e)', async () => {
+  const app = await createServer();
+  let userId: string;
+  let token: string;
+
+  let usersRepository: IUsersRepository;
+  let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+
+  beforeAll(async () => {
+    await app.ready();
+    ({ token, userId } = await getSupabaseAccessToken(app));
+    usersRepository = new PrismaUsersRepository();
+    poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should be able to leave a pool', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'pool-owner-leave@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: userId,
+    });
+
+    // Then leave the pool
+    const response = await request(app.server)
+      .post(`/pools/${pool.id}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('should return 404 when trying to leave a pool that does not exist', async () => {
+    const nonExistentPoolId = 9999;
+
+    const response = await request(app.server)
+      .post(`/pools/${nonExistentPoolId}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should return 403 when trying to leave a pool that user is not a participant of', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'not-joined-pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    const response = await request(app.server)
+      .post(`/pools/${pool.id}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(403);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('not a participant');
+  });
+
+  it('should return 403 when trying to leave a pool as the owner', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+
+    // Create a pool where the authenticated user is the owner
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    const response = await request(app.server)
+      .post(`/pools/${pool.id}/leave`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(403);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain(
+      'Unauthorized: Pool creator cannot leave their own pool'
+    );
+  });
+
+  it('should require authentication', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'auth-test-pool-owner-leave@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+    });
+
+    const response = await request(app.server).post(`/pools/${pool.id}/leave`);
+
+    expect(response.statusCode).toEqual(401);
+  });
+});

--- a/src/useCases/pools/leavePoolUseCase.ts
+++ b/src/useCases/pools/leavePoolUseCase.ts
@@ -1,6 +1,8 @@
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
 import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+import { NotParticipantError } from './errors/NotParticipantError';
+import { UnauthorizedError } from './errors/UnauthorizedError';
 
 interface ILeavePoolRequest {
   poolId: number;
@@ -31,12 +33,12 @@ export class LeavePoolUseCase {
     const isParticipant = participants.some((participant) => participant.userId === userId);
 
     if (!isParticipant) {
-      throw new Error('User is not a participant in this pool');
+      throw new NotParticipantError('User is not a participant in this pool');
     }
 
     // Check if user is the creator (creators cannot leave their own pools)
     if (pool.creatorId === userId) {
-      throw new Error('Pool creator cannot leave their own pool');
+      throw new UnauthorizedError('Pool creator cannot leave their own pool');
     }
 
     // Remove user from pool participants


### PR DESCRIPTION
- Added `NotParticipantError` and `UnauthorizedError` to handle specific error scenarios in the leave pool use case.
- Updated `leavePoolUseCase` to throw `NotParticipantError` if the user is not a participant and `UnauthorizedError` if the user is the pool creator.
- Modified `leavePoolController` to handle `ResourceNotFoundError`, `NotParticipantError`, and `UnauthorizedError`, returning appropriate HTTP status codes (404 and 403 respectively).
- Added e2e tests for the `leavePoolController`, including tests for successful leaving, handling non-existent pools, users not being participants, pool owners attempting to leave, and authentication requirements.