### PR TITLE
:hammer: feat: Implement remove user from pool functionality

### DIFF
--- a/src/http/controllers/pools/removeUserFromPoolController.spec.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.spec.ts
@@ -1,0 +1,183 @@
+import { createServer } from '@/app';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createPool } from '@/test/mocks/pools';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('Remove User From Pool Controller (e2e)', async () => {
+  const app = await createServer();
+  let userId: string;
+  let token: string;
+
+  let usersRepository: IUsersRepository;
+  let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+
+  beforeAll(async () => {
+    await app.ready();
+    ({ token, userId } = await getSupabaseAccessToken(app));
+    usersRepository = new PrismaUsersRepository();
+    poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should be able to remove a user from a pool', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    const userToRemove = await createUser(usersRepository, {
+      email: 'user-to-remove@example.com',
+    });
+
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: userToRemove.id,
+    });
+
+    const response = await request(app.server)
+      .delete(`/pools/${pool.id}/users/${userToRemove.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const participants = await poolsRepository.getPoolParticipants(pool.id);
+    const isUserStillParticipant = participants.some(
+      (participant) => participant.userId === userToRemove.id
+    );
+    expect(isUserStillParticipant).toBe(false);
+  });
+
+  it('should return 404 when trying to remove a user from a non-existent pool', async () => {
+    const nonExistentPoolId = 9999;
+    const userToRemove = await createUser(usersRepository, {
+      email: 'user-to-remove-non-existent-pool@example.com',
+    });
+
+    const response = await request(app.server)
+      .delete(`/pools/${nonExistentPoolId}/users/${userToRemove.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should return 404 when trying to remove a non-existent user from a pool', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    const nonExistentUserId = 'clh0000000000000000000000000'; // Non-existent CUID
+
+    const response = await request(app.server)
+      .delete(`/pools/${pool.id}/users/${nonExistentUserId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  it('should return 403 when a non-creator tries to remove a user from a pool', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+
+    const poolOwner = await createUser(usersRepository, {
+      email: 'pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: poolOwner.id,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    const userToRemove = await createUser(usersRepository, {
+      email: 'user-to-remove-non-creator@example.com',
+    });
+
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: userToRemove.id,
+    });
+
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: userId,
+    });
+
+    // Try to remove the user from the pool (should fail as authenticated user is not the creator)
+    const response = await request(app.server)
+      .delete(`/pools/${pool.id}/users/${userToRemove.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(403);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('Unauthorized');
+  });
+
+  it('should return 403 when trying to remove a user who is not a participant', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+
+    // Create a pool where the authenticated user is the owner
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+
+    // Create a user who is not a participant
+    const nonParticipantUser = await createUser(usersRepository, {
+      email: 'non-participant@example.com',
+    });
+
+    // Try to remove the non-participant user
+    const response = await request(app.server)
+      .delete(`/pools/${pool.id}/users/${nonParticipantUser.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(403);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('not a participant');
+  });
+
+  it('should require authentication', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+    });
+
+    const userToRemove = await createUser(usersRepository, {
+      email: 'user-to-remove-auth@example.com',
+    });
+
+    // Add the user to the pool
+    await poolsRepository.addParticipant({
+      poolId: pool.id,
+      userId: userToRemove.id,
+    });
+
+    // Try to remove without authentication
+    const response = await request(app.server).delete(`/pools/${pool.id}/users/${userToRemove.id}`);
+
+    expect(response.statusCode).toEqual(401);
+  });
+});

--- a/src/http/controllers/pools/removeUserFromPoolController.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.ts
@@ -1,3 +1,6 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { NotParticipantError } from '@/useCases/pools/errors/NotParticipantError';
+import { UnauthorizedError } from '@/useCases/pools/errors/UnauthorizedError';
 import { makeRemoveUserFromPoolUseCase } from '@/useCases/pools/factory/makeRemoveUserFromPoolUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
@@ -5,13 +8,13 @@ import { z } from 'zod';
 export async function removeUserFromPoolController(request: FastifyRequest, reply: FastifyReply) {
   const removeUserFromPoolParamsSchema = z.object({
     poolId: z.coerce.number(),
-    userId: z.string().uuid(),
+    userId: z.string().cuid(),
   });
 
-  const { poolId, userId: userIdToRemove } = removeUserFromPoolParamsSchema.parse(request.params);
-  const creatorId = request.user.sub;
-
   try {
+    const { poolId, userId: userIdToRemove } = removeUserFromPoolParamsSchema.parse(request.params);
+    const creatorId = request.user.sub;
+
     const removeUserFromPoolUseCase = makeRemoveUserFromPoolUseCase();
     await removeUserFromPoolUseCase.execute({
       poolId,
@@ -21,8 +24,14 @@ export async function removeUserFromPoolController(request: FastifyRequest, repl
 
     return reply.status(200).send();
   } catch (error) {
-    if (error instanceof Error) {
-      return reply.status(400).send({ message: error.message });
+    if (error instanceof ResourceNotFoundError) {
+      return reply.status(404).send({ message: error.message });
+    }
+    if (error instanceof UnauthorizedError) {
+      return reply.status(403).send({ message: error.message });
+    }
+    if (error instanceof NotParticipantError) {
+      return reply.status(403).send({ message: error.message });
     }
 
     return reply.status(500).send({ message: 'Internal server error' });

--- a/src/useCases/pools/removeUserFromPoolUseCase.ts
+++ b/src/useCases/pools/removeUserFromPoolUseCase.ts
@@ -1,6 +1,8 @@
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
 import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+import { NotParticipantError } from './errors/NotParticipantError';
+import { UnauthorizedError } from './errors/UnauthorizedError';
 
 interface IRemoveUserFromPoolRequest {
   poolId: number;
@@ -23,7 +25,7 @@ export class RemoveUserFromPoolUseCase {
 
     // Verify the requester is the pool creator
     if (pool.creatorId !== creatorId) {
-      throw new Error('Only the pool creator can remove users');
+      throw new UnauthorizedError('Only the pool creator can remove users');
     }
 
     // Verify user to remove exists
@@ -37,7 +39,7 @@ export class RemoveUserFromPoolUseCase {
     const isParticipant = participants.some((participant) => participant.userId === userIdToRemove);
 
     if (!isParticipant) {
-      throw new Error('User is not a participant in this pool');
+      throw new NotParticipantError('User is not a participant in this pool');
     }
 
     // Remove user from pool participants


### PR DESCRIPTION
- Added `NotParticipantError` and `UnauthorizedError` to handle specific error scenarios in the remove user from pool use case.
- Updated `removeUserFromPoolUseCase` to throw `NotParticipantError` if the user is not a participant and `UnauthorizedError` if the user is not the pool creator.
- Modified `removeUserFromPoolController` to handle `ResourceNotFoundError`, `NotParticipantError`, and `UnauthorizedError`, returning appropriate HTTP status codes (404 and 403 respectively).
- Added e2e tests for the `removeUserFromPoolController`, including tests for successful removal, handling non-existent pools, users not being participants, pool owners attempting to remove, and authentication requirements.