### PR TITLE
:sparkles: feat: Implement update match functionality

### DIFF
--- a/src/http/controllers/matches/updateMatchController.spec.ts
+++ b/src/http/controllers/matches/updateMatchController.spec.ts
@@ -1,0 +1,307 @@
+import { createServer } from '@/app';
+import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
+import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
+import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
+import { PrismaTeamsRepository } from '@/repositories/teams/PrismaTeamsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createMatch, createMatchWithTeams } from '@/test/mocks/match';
+import { createTeam } from '@/test/mocks/teams';
+import { createTournament } from '@/test/mocks/tournament';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('Update Match Controller (e2e)', async () => {
+  const app = await createServer();
+  let userId: string;
+  let token: string;
+
+  let matchesRepository: IMatchesRepository;
+  let teamsRepository: ITeamsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+
+  beforeAll(async () => {
+    await app.ready();
+    ({ token, userId } = await getSupabaseAccessToken(app));
+    matchesRepository = new PrismaMatchesRepository();
+    teamsRepository = new PrismaTeamsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should be able to update a match', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Home Team' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Away Team' });
+
+    const match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Test Stadium',
+        matchStatus: 'SCHEDULED',
+        matchStage: 'GROUP',
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    const updatedStadium = 'Updated Stadium';
+    const updatedMatchDate = new Date();
+    updatedMatchDate.setDate(updatedMatchDate.getDate() + 1); // Set to tomorrow
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        stadium: updatedStadium,
+        matchDate: updatedMatchDate.toISOString(),
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('match');
+    expect(response.body.match).toHaveProperty('id', match.id);
+    expect(response.body.match).toHaveProperty('stadium', updatedStadium);
+
+    const updatedMatch = await matchesRepository.findById(match.id);
+    expect(updatedMatch).not.toBeNull();
+    expect(updatedMatch?.stadium).toEqual(updatedStadium);
+  });
+
+  it('should be able to update match scores', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+
+    const { match } = await createMatchWithTeams(
+      {
+        matchesRepository,
+        teamsRepository,
+      },
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Another Test Stadium',
+        matchStatus: 'IN_PROGRESS',
+        matchStage: 'GROUP',
+      }
+    );
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        homeScore: 2,
+        awayScore: 1,
+        matchStatus: 'COMPLETED',
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('match');
+    expect(response.body.match).toHaveProperty('id', match.id);
+    expect(response.body.match).toHaveProperty('homeTeamScore', 2);
+    expect(response.body.match).toHaveProperty('awayTeamScore', 1);
+    expect(response.body.match).toHaveProperty('matchStatus', 'COMPLETED');
+  });
+
+  it('should not allow setting scores for a scheduled match', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Home Team 3' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Away Team 3' });
+
+    const match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Test Stadium 3',
+        matchStatus: 'SCHEDULED',
+        matchStage: 'GROUP',
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        homeScore: 2,
+        awayScore: 1,
+      });
+
+    expect(response.statusCode).toEqual(400);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('Cannot set score');
+  });
+
+  it('should be able to update a knockout match with extra time', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Home Team 4' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Away Team 4' });
+
+    const match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Test Stadium 4',
+        matchStatus: 'IN_PROGRESS',
+        matchStage: 'SEMI_FINAL',
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        homeScore: 1,
+        awayScore: 1,
+        hasExtraTime: true,
+        matchStatus: 'COMPLETED',
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('match');
+    expect(response.body.match).toHaveProperty('id', match.id);
+    expect(response.body.match).toHaveProperty('hasExtraTime', true);
+  });
+
+  it('should be able to update a knockout match with penalties', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Home Team 5' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Away Team 5' });
+
+    const match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Test Stadium 5',
+        matchStatus: 'IN_PROGRESS',
+        matchStage: 'FINAL',
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        homeScore: 2,
+        awayScore: 2,
+        hasExtraTime: true,
+        hasPenalties: true,
+        penaltyHomeScore: 5,
+        penaltyAwayScore: 4,
+        matchStatus: 'COMPLETED',
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('match');
+    expect(response.body.match).toHaveProperty('id', match.id);
+    expect(response.body.match).toHaveProperty('hasExtraTime', true);
+    expect(response.body.match).toHaveProperty('hasPenalties', true);
+    expect(response.body.match).toHaveProperty('penaltyHomeScore', 5);
+    expect(response.body.match).toHaveProperty('penaltyAwayScore', 4);
+  });
+
+  it('should not allow penalties without extra time', async () => {
+    // Create test data
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Home Team 6' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Away Team 6' });
+
+    const match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Test Stadium 6',
+        matchStatus: 'IN_PROGRESS',
+        matchStage: 'FINAL',
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        homeScore: 2,
+        awayScore: 2,
+        hasPenalties: true,
+        penaltyHomeScore: 5,
+        penaltyAwayScore: 4,
+      });
+
+    expect(response.statusCode).toEqual(400);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('Penalties can only be set when extra time is set');
+  });
+
+  it('should not allow penalties with different scores', async () => {
+    // Create test data
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Home Team 7' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Away Team 7' });
+
+    const match = await createMatch(
+      matchesRepository,
+      {
+        tournamentId: tournament.id,
+        matchDatetime: new Date(),
+        stadium: 'Test Stadium 7',
+        matchStatus: 'IN_PROGRESS',
+        matchStage: 'FINAL',
+      },
+      homeTeam,
+      awayTeam
+    );
+
+    const response = await request(app.server)
+      .put(`/matches/${match.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        homeScore: 2,
+        awayScore: 1, // Different score
+        hasExtraTime: true,
+        hasPenalties: true,
+        penaltyHomeScore: 5,
+        penaltyAwayScore: 4,
+      });
+
+    expect(response.statusCode).toEqual(400);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('Penalties can only occur when scores are tied');
+  });
+
+  it('should return 404 when match does not exist', async () => {
+    const nonExistentMatchId = 9999;
+
+    const response = await request(app.server)
+      .put(`/matches/${nonExistentMatchId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        stadium: 'Updated Stadium',
+      });
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.body).toHaveProperty('message', 'Resource not found: Match not found');
+  });
+
+  it('should require authentication', async () => {
+    const response = await request(app.server).put('/matches/1').send({
+      stadium: 'Updated Stadium',
+    });
+
+    expect(response.statusCode).toEqual(401);
+  });
+});

--- a/src/http/controllers/matches/updateMatchController.ts
+++ b/src/http/controllers/matches/updateMatchController.ts
@@ -1,0 +1,99 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { MatchUpdateError } from '@/useCases/matches/errors/MatchUpdateError';
+import { makeUpdateMatchUseCase } from '@/useCases/matches/factories/makeUpdateMatchUseCase';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+export async function updateMatchController(
+  request: FastifyRequest<{
+    Params: { matchId: string };
+    Body: {
+      homeTeam?: number;
+      awayTeam?: number;
+      homeScore?: number;
+      awayScore?: number;
+      matchDate?: string;
+      matchStatus?: string;
+      matchStage?: string;
+      hasExtraTime?: boolean;
+      hasPenalties?: boolean;
+      penaltyHomeScore?: number;
+      penaltyAwayScore?: number;
+      stadium?: string;
+    };
+  }>,
+  reply: FastifyReply
+) {
+  const updateMatchParamsSchema = z.object({
+    matchId: z.coerce.number(),
+  });
+
+  const updateMatchBodySchema = z.object({
+    homeTeam: z.number().optional(),
+    awayTeam: z.number().optional(),
+    homeScore: z.number().optional(),
+    awayScore: z.number().optional(),
+    matchDate: z.string().datetime().optional(),
+    matchStatus: z
+      .enum(['SCHEDULED', 'IN_PROGRESS', 'COMPLETED', 'POSTPONED', 'CANCELLED'])
+      .optional(),
+    matchStage: z
+      .enum(['GROUP', 'ROUND_OF_16', 'QUARTER_FINAL', 'SEMI_FINAL', 'THIRD_PLACE', 'FINAL'])
+      .optional(),
+    hasExtraTime: z.boolean().optional(),
+    hasPenalties: z.boolean().optional(),
+    penaltyHomeScore: z.number().optional(),
+    penaltyAwayScore: z.number().optional(),
+    stadium: z.string().optional(),
+  });
+
+  const { matchId } = updateMatchParamsSchema.parse(request.params);
+  const {
+    homeTeam,
+    awayTeam,
+    homeScore,
+    awayScore,
+    matchDate,
+    matchStatus,
+    matchStage,
+    hasExtraTime,
+    hasPenalties,
+    penaltyHomeScore,
+    penaltyAwayScore,
+    stadium,
+  } = updateMatchBodySchema.parse(request.body);
+
+  try {
+    const updateMatchUseCase = makeUpdateMatchUseCase();
+
+    const match = await updateMatchUseCase.execute({
+      matchId,
+      homeTeam,
+      awayTeam,
+      homeScore,
+      awayScore,
+      matchDate: matchDate ? new Date(matchDate) : undefined,
+      matchStatus: matchStatus as any,
+      matchStage: matchStage as any,
+      hasExtraTime,
+      hasPenalties,
+      penaltyHomeScore,
+      penaltyAwayScore,
+      stadium,
+    });
+
+    return reply.status(200).send({
+      match,
+    });
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return reply.status(404).send({ message: error.message });
+    }
+
+    if (error instanceof MatchUpdateError) {
+      return reply.status(400).send({ message: error.message });
+    }
+
+    throw error;
+  }
+}

--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -2,10 +2,12 @@ import { verifyJwt } from '@/http/middlewares/verifyJWT';
 import { FastifyInstance } from 'fastify';
 import { getMatchController } from '../controllers/matches/getMatchController';
 import { getMatchPredictions } from '../controllers/matches/getMatchPredictions';
+import { updateMatchController } from '../controllers/matches/updateMatchController';
 
 export async function matchesRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
   app.get('/matches/:matchId', getMatchController);
   app.get('/matches/:matchId/predictions', getMatchPredictions);
+  app.put('/matches/:matchId', updateMatchController);
 }

--- a/src/useCases/matches/errors/MatchUpdateError.ts
+++ b/src/useCases/matches/errors/MatchUpdateError.ts
@@ -1,0 +1,7 @@
+export class MatchUpdateError extends Error {
+  constructor(message: string = 'Error updating match') {
+    super(`Match update error: ${message}`);
+    this.name = 'MatchUpdateError';
+    Object.setPrototypeOf(this, MatchUpdateError.prototype);
+  }
+}

--- a/src/useCases/matches/factories/makeUpdateMatchUseCase.ts
+++ b/src/useCases/matches/factories/makeUpdateMatchUseCase.ts
@@ -1,0 +1,11 @@
+import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { UpdateMatchUseCase } from '../updateMatchUseCase';
+
+export function makeUpdateMatchUseCase() {
+  const matchesRepository = new PrismaMatchesRepository();
+  const tournamentsRepository = new PrismaTournamentsRepository();
+  const updateMatchUseCase = new UpdateMatchUseCase(matchesRepository, tournamentsRepository);
+
+  return updateMatchUseCase;
+}


### PR DESCRIPTION
- Added `updateMatchController` to handle PUT requests for updating match details, including score, status, date, and stadium.
- Implemented `UpdateMatchUseCase` to validate and update match data, including checks for valid scores, extra time, penalties, and match status.
- Added `MatchUpdateError` to handle specific error scenarios during match updates.
- Added a route `/matches/:matchId` to the `matchesRoutes` to handle PUT requests for a specific match.
- Added e2e tests for the `updateMatchController`, including tests for updating match details, scores, handling invalid updates, and authentication requirements.
- Added `makeUpdateMatchUseCase` factory to instantiate the `UpdateMatchUseCase`.