### PR TITLE
:sparkles: Implement pool update functionality and e2e tests

### DIFF
--- a/src/http/controllers/pools/updatePoolController.spec.ts
+++ b/src/http/controllers/pools/updatePoolController.spec.ts
@@ -1,0 +1,165 @@
+import { createServer } from '@/app';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createPool } from '@/test/mocks/pools';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+import { Pool } from '@prisma/client';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('Update Pool Controller (e2e)', async () => {
+  const app = await createServer();
+  let userId: string;
+  let token: string;
+  let tournamentId: number;
+  let pool: Pool;
+  let otherUserId: string;
+  let otherUserToken: string;
+
+  let usersRepository: IUsersRepository;
+  let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+
+  beforeAll(async () => {
+    await app.ready();
+    ({ token, userId } = await getSupabaseAccessToken(app));
+
+    usersRepository = new PrismaUsersRepository();
+    poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+
+    // Create a tournament for testing
+    const tournament = await createTournament(tournamentsRepository, {});
+    tournamentId = tournament.id;
+
+    // Create a pool for testing
+    const createResponse = await request(app.server)
+      .post('/pools')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Test Pool for Update',
+        description: 'This is a test pool for update tests',
+        tournamentId,
+        isPrivate: true,
+        maxParticipants: 10,
+      });
+
+    pool = createResponse.body.pool;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should update only the provided fields', async () => {
+    // Update only the name
+    const response = await request(app.server)
+      .put(`/pools/${pool.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Only Name Updated',
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body.pool).toHaveProperty('name', 'Only Name Updated');
+    expect(response.body.pool).toHaveProperty('description', pool.description);
+    expect(response.body.pool).toHaveProperty('isPrivate', pool.isPrivate);
+    expect(response.body.pool).toHaveProperty('maxParticipants', pool.maxParticipants);
+  });
+
+  it('should update a pool successfully', async () => {
+    const response = await request(app.server)
+      .put(`/pools/${pool.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated Pool Name',
+        description: 'Updated description',
+        maxParticipants: 20,
+      });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pool');
+    expect(response.body.pool).toHaveProperty('id', pool.id);
+    expect(response.body.pool.name).toBe('Updated Pool Name');
+    expect(response.body.pool.description).toBe('Updated description');
+    expect(response.body.pool.maxParticipants).toBe(20);
+    expect(response.body.pool.isPrivate).toBe(true); // Should remain unchanged
+  });
+
+  it('should return 422 when validation fails', async () => {
+    const response = await request(app.server)
+      .put(`/pools/${pool.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Te', // Too short
+      });
+
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toHaveProperty('message', 'Validation error');
+    expect(response.body).toHaveProperty('issues');
+  });
+
+  it('should return 404 when pool does not exist', async () => {
+    const nonExistentPoolId = 9999;
+
+    const response = await request(app.server)
+      .put(`/pools/${nonExistentPoolId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated Pool Name',
+      });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('not found');
+  });
+
+  it('should return 403 when user is not the pool creator', async () => {
+    const poolOwner = await createUser(usersRepository, {
+      email: 'pool-owner@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: poolOwner.id,
+      tournamentId: tournamentId,
+      isPrivate: false,
+    });
+
+    const response = await request(app.server)
+      .put(`/pools/${pool.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Unauthorized Update',
+      });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message).toContain('Not pool creator');
+  });
+
+  it('should require authentication', async () => {
+    const response = await request(app.server).put(`/pools/${pool.id}`).send({
+      name: 'Unauthenticated Update',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should handle invalid pool ID parameter', async () => {
+    const response = await request(app.server)
+      .put('/pools/invalid-id')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Valid Name',
+      });
+
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toHaveProperty('message', 'Validation error');
+  });
+});

--- a/src/http/controllers/pools/updatePoolController.ts
+++ b/src/http/controllers/pools/updatePoolController.ts
@@ -1,0 +1,58 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { NotPoolCreatorError } from '@/useCases/pools/errors/NotPoolCreatorError';
+import { makeUpdatePoolUseCase } from '@/useCases/pools/factory/makeUpdatePoolUseCase';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+export async function updatePoolController(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const updatePoolParamsSchema = z.object({
+      poolId: z.coerce.number(),
+    });
+
+    const updatePoolBodySchema = z.object({
+      name: z.string().min(3).optional(),
+      description: z.string().optional(),
+      isPrivate: z.boolean().optional(),
+      maxParticipants: z.number().optional(),
+      registrationDeadline: z.date().optional(),
+    });
+
+    const { poolId } = updatePoolParamsSchema.parse(request.params);
+    const { name, description, isPrivate, maxParticipants, registrationDeadline } =
+      updatePoolBodySchema.parse(request.body);
+
+    const userId = request.user.sub;
+
+    const updatePoolUseCase = makeUpdatePoolUseCase();
+
+    const updatedPool = await updatePoolUseCase.execute({
+      poolId,
+      userId,
+      name,
+      description,
+      isPrivate,
+      maxParticipants,
+      registrationDeadline,
+    });
+
+    return reply.status(200).send({
+      pool: updatedPool,
+    });
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return reply.status(404).send({ message: error.message });
+    }
+
+    if (error instanceof z.ZodError) {
+      return reply.status(422).send({ message: 'Validation error', issues: error.format() });
+    }
+
+    if (error instanceof NotPoolCreatorError) {
+      return reply.status(403).send({ message: error.message });
+    }
+
+    console.error(error);
+    return reply.status(500).send({ message: 'Internal server error.' });
+  }
+}

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -4,6 +4,7 @@ import { getPoolUsersController } from '../controllers/pools/getPoolUsersControl
 import { JoinPoolController } from '../controllers/pools/joinPoolController';
 import { leavePoolController } from '../controllers/pools/leavePoolController';
 import { removeUserFromPoolController } from '../controllers/pools/removeUserFromPoolController';
+import { updatePoolController } from '../controllers/pools/updatePoolController';
 import { verifyJwt } from '../middlewares/verifyJWT';
 
 export async function PoolRoutes(app: FastifyInstance) {
@@ -14,4 +15,5 @@ export async function PoolRoutes(app: FastifyInstance) {
   app.post('/pools/:poolId/leave', leavePoolController);
   app.delete('/pools/:poolId/users/:userId', removeUserFromPoolController);
   app.get('/pools/:poolId/users', getPoolUsersController);
+  app.put('/pools/:poolId', updatePoolController);
 }

--- a/src/useCases/pools/errors/NotPoolCreatorError.ts
+++ b/src/useCases/pools/errors/NotPoolCreatorError.ts
@@ -1,0 +1,7 @@
+export class NotPoolCreatorError extends Error {
+  constructor(info: string) {
+    super(`Not pool creator: ${info}`);
+    this.name = 'NotPoolCreatorError';
+    Object.setPrototypeOf(this, NotPoolCreatorError.prototype);
+  }
+}

--- a/src/useCases/pools/updatePoolUseCase.ts
+++ b/src/useCases/pools/updatePoolUseCase.ts
@@ -1,6 +1,7 @@
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
 import { IUsersRepository } from '../../repositories/users/IUsersRepository';
+import { NotPoolCreatorError } from './errors/NotPoolCreatorError';
 
 interface IUpdatePoolRequest {
   poolId: number;
@@ -38,9 +39,8 @@ export class UpdatePoolUseCase {
     }
 
     if (pool.creatorId !== userId) {
-      throw new Error('Only the pool creator can update the pool');
+      throw new NotPoolCreatorError(`User ${userId} is not the creator of pool ${poolId}`);
     }
-
     const updatedPool = await this.poolsRepository.update(poolId, {
       name,
       description,


### PR DESCRIPTION
- Added `NotPoolCreatorError` to handle the scenario where a user tries to update a pool they did not create.
- Implemented `updatePoolUseCase` to validate if the user is the pool creator before updating the pool.
- Added `updatePoolController` to handle PUT requests for updating a pool, including input validation, error handling for `ResourceNotFoundError`, `NotPoolCreatorError` and response formatting.
- Added a route `/pools/:poolId` to `pools.routes.ts` to handle PUT requests for updating a pool.
- Added e2e tests for the `updatePoolController`, including tests for updating pool details, handling validation errors, handling non-existent pools, handling unauthorized updates, and authentication requirements.