### PR TITLE
Fix user pools controller to use route param

### DIFF
--- a/src/http/controllers/user/getUserPoolsController.ts
+++ b/src/http/controllers/user/getUserPoolsController.ts
@@ -1,10 +1,18 @@
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { makeGetUserPoolsUseCase } from '@/useCases/pools/factory/makeGetUserPoolsUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
 
-export async function getUserPoolsContoller(request: FastifyRequest, reply: FastifyReply) {
+export async function getUserPoolsController(
+  request: FastifyRequest<{ Params: { userId: string } }>,
+  reply: FastifyReply
+) {
   try {
-    const userId = request.user.sub;
+    const paramsSchema = z.object({
+      userId: z.string(),
+    });
+
+    const { userId } = paramsSchema.parse(request.params);
 
     const getUserPoolsUseCase = makeGetUserPoolsUseCase();
     const { pools } = await getUserPoolsUseCase.execute({

--- a/src/http/routes/user.routes.ts
+++ b/src/http/routes/user.routes.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { CreateUserController } from '../controllers/user/createUserController';
 import { GetUserInfoController } from '../controllers/user/getUserInfoController';
-import { getUserPoolsContoller } from '../controllers/user/getUserPoolsController';
+import { getUserPoolsController } from '../controllers/user/getUserPoolsController';
 import { UpdateUserController } from '../controllers/user/updateUserController';
 import { verifyJwt } from '../middlewares/verifyJWT';
 
@@ -11,5 +11,5 @@ export async function UserRoutes(app: FastifyInstance) {
   app.post('/users', CreateUserController);
   app.put('/users/:userId', UpdateUserController);
   app.get('/users/:userId', GetUserInfoController);
-  app.get('/users/:userId/pools', getUserPoolsContoller);
+  app.get('/users/:userId/pools', getUserPoolsController);
 }


### PR DESCRIPTION
## Summary
- parse `userId` route parameter in `getUserPoolsController`
- update routes to use renamed controller

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e65533208328b2fc23e166fd001e