### PR TITLE
Refactor pool authorization service

### DIFF
--- a/src/http/controllers/pools/getPoolPredictionsController.spec.ts
+++ b/src/http/controllers/pools/getPoolPredictionsController.spec.ts
@@ -153,7 +153,9 @@ describe('Get Pool Predictions Controller (e2e)', async () => {
 
     expect(response.statusCode).toEqual(403);
     expect(response.body).toHaveProperty('message');
-    expect(response.body.message).toContain('You must be a participant');
+    expect(response.body.message).toContain(
+      'Not participant: User is not a participant or the creator of the pool'
+    );
   });
 
   it('should return 404 when pool does not exist', async () => {

--- a/src/services/pools/PoolAuthorizationService.ts
+++ b/src/services/pools/PoolAuthorizationService.ts
@@ -1,0 +1,44 @@
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { NotParticipantError } from '@/useCases/pools/errors/NotParticipantError';
+
+interface IPoolAuthorizationResult {
+  isCreator: boolean;
+  isParticipant: boolean;
+  hasAccess: boolean;
+}
+
+export class PoolAuthorizationService {
+  constructor(private poolsRepository: IPoolsRepository) {}
+
+  async checkUserPoolAccess(
+    poolId: number,
+    userId: string,
+    creatorId: string
+  ): Promise<IPoolAuthorizationResult> {
+    const participants = await this.poolsRepository.getPoolParticipants(poolId);
+
+    const isParticipant = participants.some((participant) => participant.userId === userId);
+    const isCreator = creatorId === userId;
+    const hasAccess = isParticipant || isCreator;
+
+    return {
+      isCreator,
+      isParticipant,
+      hasAccess,
+    };
+  }
+
+  async validateUserPoolAccess(
+    poolId: number,
+    userId: string,
+    creatorId: string
+  ): Promise<IPoolAuthorizationResult> {
+    const result = await this.checkUserPoolAccess(poolId, userId, creatorId);
+
+    if (!result.hasAccess) {
+      throw new NotParticipantError('User is not a participant or the creator of the pool');
+    }
+
+    return result;
+  }
+}

--- a/src/useCases/pools/factory/makeGetPoolPredictionsUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolPredictionsUseCase.ts
@@ -1,11 +1,16 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { GetPoolPredictionsUseCase } from '../getPoolsPredictionsUseCase';
 
 export function makeGetPoolPredictionsUseCase() {
   const predictionsRepository = new PrismaPredictionsRepository();
   const poolsRepository = new PrismaPoolsRepository();
-  const useCase = new GetPoolPredictionsUseCase(predictionsRepository, poolsRepository);
-
+  const poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+  const useCase = new GetPoolPredictionsUseCase(
+    predictionsRepository,
+    poolsRepository,
+    poolAuthorizationService
+  );
   return useCase;
 }

--- a/src/useCases/pools/factory/makeGetPoolStandingsUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolStandingsUseCase.ts
@@ -1,9 +1,14 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { GetPoolStandingsUseCase } from '../getPoolStandingsUseCase';
 
 export function makeGetPoolStandingsUseCase() {
   const poolsRepository = new PrismaPoolsRepository();
-  const getPoolStandingsUseCase = new GetPoolStandingsUseCase(poolsRepository);
+  const poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+  const getPoolStandingsUseCase = new GetPoolStandingsUseCase(
+    poolsRepository,
+    poolAuthorizationService
+  );
 
   return getPoolStandingsUseCase;
 }

--- a/src/useCases/pools/factory/makeGetPoolUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolUseCase.ts
@@ -1,6 +1,7 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { GetPoolUseCase } from '../getPoolUseCase';
 
 export function makeGetPoolUseCase() {
@@ -8,10 +9,13 @@ export function makeGetPoolUseCase() {
   const usersRepository = new PrismaUsersRepository();
   const tournamentsRepository = new PrismaTournamentsRepository();
 
+  const poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+
   const getPoolUseCase = new GetPoolUseCase(
     poolsRepository,
     usersRepository,
-    tournamentsRepository
+    tournamentsRepository,
+    poolAuthorizationService
   );
 
   return getPoolUseCase;

--- a/src/useCases/pools/factory/makeGetPoolUsersUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolUsersUseCase.ts
@@ -1,11 +1,17 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { GetPoolUsersUseCase } from '../getPoolUsersUseCase';
 
 export function makeGetPoolUsersUseCase() {
   const poolsRepository = new PrismaPoolsRepository();
   const usersRepository = new PrismaUsersRepository();
-  const useCase = new GetPoolUsersUseCase(poolsRepository, usersRepository);
+  const poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+  const useCase = new GetPoolUsersUseCase(
+    poolsRepository,
+    usersRepository,
+    poolAuthorizationService
+  );
 
   return useCase;
 }

--- a/src/useCases/pools/factory/makeLeavePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeLeavePoolUseCase.ts
@@ -1,11 +1,16 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { LeavePoolUseCase } from '../leavePoolUseCase';
 
 export function makeLeavePoolUseCase() {
   const poolsRepository = new PrismaPoolsRepository();
   const usersRepository = new PrismaUsersRepository();
-  const leavePoolUseCase = new LeavePoolUseCase(poolsRepository, usersRepository);
-
+  const poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+  const leavePoolUseCase = new LeavePoolUseCase(
+    poolsRepository,
+    usersRepository,
+    poolAuthorizationService
+  );
   return leavePoolUseCase;
 }

--- a/src/useCases/pools/factory/makeUpdatePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeUpdatePoolUseCase.ts
@@ -1,11 +1,13 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { UpdatePoolUseCase } from '../updatePoolUseCase';
 
 export function makeUpdatePoolUseCase() {
   const poolsRepository = new PrismaPoolsRepository();
   const usersRepository = new PrismaUsersRepository();
-  const useCase = new UpdatePoolUseCase(poolsRepository, usersRepository);
+  const poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+  const useCase = new UpdatePoolUseCase(poolsRepository, usersRepository, poolAuthorizationService);
 
   return useCase;
 }

--- a/src/useCases/pools/getPoolStandingsUseCase.spec.ts
+++ b/src/useCases/pools/getPoolStandingsUseCase.spec.ts
@@ -4,6 +4,7 @@ import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepos
 import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
 import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { createMatch } from '@/test/mocks/match';
 import { createPool } from '@/test/mocks/pools';
 import { createPrediction } from '@/test/mocks/predictions';
@@ -19,6 +20,7 @@ describe('GetPoolStandingsUseCase', () => {
   let matchesRepository: InMemoryMatchesRepository;
   let teamsRepository: InMemoryTeamsRepository;
   let predictionsRepository: InMemoryPredictionsRepository;
+  let poolAuthorizationService: PoolAuthorizationService;
   let sut: GetPoolStandingsUseCase;
 
   let creator: User;
@@ -32,7 +34,8 @@ describe('GetPoolStandingsUseCase', () => {
     teamsRepository = new InMemoryTeamsRepository();
     matchesRepository = new InMemoryMatchesRepository();
     predictionsRepository = new InMemoryPredictionsRepository();
-    sut = new GetPoolStandingsUseCase(poolsRepository);
+    poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+    sut = new GetPoolStandingsUseCase(poolsRepository, poolAuthorizationService);
 
     creator = await createUser(usersRepository, {
       fullName: 'Creator User',

--- a/src/useCases/pools/getPoolUseCase.spec.ts
+++ b/src/useCases/pools/getPoolUseCase.spec.ts
@@ -5,12 +5,14 @@ import { InMemoryTournamentsRepository } from '@/repositories/tournaments/InMemo
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { GetPoolUseCase } from './getPoolUseCase';
 
 let poolsRepository: IPoolsRepository;
 let usersRepository: IUsersRepository;
 let tournamentRepository: ITournamentsRepository;
+let poolAuthorizationService: PoolAuthorizationService;
 let sut: GetPoolUseCase;
 
 describe('Get Pool Use Case', () => {
@@ -18,7 +20,13 @@ describe('Get Pool Use Case', () => {
     poolsRepository = new InMemoryPoolsRepository();
     usersRepository = new InMemoryUsersRepository();
     tournamentRepository = new InMemoryTournamentsRepository();
-    sut = new GetPoolUseCase(poolsRepository, usersRepository, tournamentRepository);
+    poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+    sut = new GetPoolUseCase(
+      poolsRepository,
+      usersRepository,
+      tournamentRepository,
+      poolAuthorizationService
+    );
   });
 
   it('should be able to get pool information with participants and scoring rules', async () => {

--- a/src/useCases/pools/getPoolUsersUseCase.spec.ts
+++ b/src/useCases/pools/getPoolUsersUseCase.spec.ts
@@ -3,19 +3,22 @@ import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepos
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { NotParticipantError } from './errors/NotParticipantError';
 import { GetPoolUsersUseCase } from './getPoolUsersUseCase';
 
 let poolsRepository: IPoolsRepository;
 let usersRepository: IUsersRepository;
+let poolAuthorizationService: PoolAuthorizationService;
 let sut: GetPoolUsersUseCase;
 
 describe('Get Pool Users Use Case', () => {
   beforeEach(() => {
     poolsRepository = new InMemoryPoolsRepository();
     usersRepository = new InMemoryUsersRepository();
-    sut = new GetPoolUsersUseCase(poolsRepository, usersRepository);
+    poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+    sut = new GetPoolUsersUseCase(poolsRepository, usersRepository, poolAuthorizationService);
   });
 
   it('should be able to get all users participating in a pool', async () => {

--- a/src/useCases/pools/leavePoolUseCase.spec.ts
+++ b/src/useCases/pools/leavePoolUseCase.spec.ts
@@ -1,3 +1,4 @@
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '../../repositories/pools/InMemoryPoolsRepository';
@@ -8,6 +9,7 @@ import { LeavePoolUseCase } from './leavePoolUseCase';
 let poolsRepository: InMemoryPoolsRepository;
 let usersRepository: InMemoryUsersRepository;
 let tournamentsRepository: InMemoryTournamentsRepository;
+let poolAuthorizationService: PoolAuthorizationService;
 let sut: LeavePoolUseCase;
 
 describe('Leave Pool Use Case', () => {
@@ -15,7 +17,8 @@ describe('Leave Pool Use Case', () => {
     poolsRepository = new InMemoryPoolsRepository();
     usersRepository = new InMemoryUsersRepository();
     tournamentsRepository = new InMemoryTournamentsRepository();
-    sut = new LeavePoolUseCase(poolsRepository, usersRepository);
+    poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+    sut = new LeavePoolUseCase(poolsRepository, usersRepository, poolAuthorizationService);
   });
 
   it('should be able to leave a pool', async () => {

--- a/src/useCases/pools/updatePoolUseCase.spec.ts
+++ b/src/useCases/pools/updatePoolUseCase.spec.ts
@@ -3,19 +3,22 @@ import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepos
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { NotPoolCreatorError } from './errors/NotPoolCreatorError';
 import { UpdatePoolUseCase } from './updatePoolUseCase';
 
 let poolsRepository: IPoolsRepository;
 let usersRepository: IUsersRepository;
+let poolAuthorizationService: PoolAuthorizationService;
 let sut: UpdatePoolUseCase;
 
 describe('Update Pool Use Case', () => {
   beforeEach(() => {
     poolsRepository = new InMemoryPoolsRepository();
     usersRepository = new InMemoryUsersRepository();
-    sut = new UpdatePoolUseCase(poolsRepository, usersRepository);
+    poolAuthorizationService = new PoolAuthorizationService(poolsRepository);
+    sut = new UpdatePoolUseCase(poolsRepository, usersRepository, poolAuthorizationService);
   });
 
   it('should be able to update a pool', async () => {


### PR DESCRIPTION
**Add `PoolAuthorizationService`** – Centralizes logic to verify participants, creators, and permissions for leaving pools, along with helper methods (`checkUserPoolAccess`, `validateUserPoolAccess`, etc.)

**Refactor use cases** – `GetPoolUseCase`, `UpdatePoolUseCase`, `LeavePoolUseCase`, `GetPoolUsersUseCase`, `GetPoolStandingsUseCase`, and `GetPoolPredictionsUseCase` now receive `PoolAuthorizationService` from their factories, replacing manual validations. Tests were updated accordingly

**Improve error messaging** – Adjusted error in getPoolPredictionsController.spec.ts for clarity

Overall: The new service consolidates pool access checks, reduces duplicate logic across use cases, and enhances error messages, preparing the code base for future pool-related features.