### PR TITLE
:recycle: feat(pools): Refactor GetPoolUseCase to use mapToResponse m…

### DIFF
--- a/src/useCases/pools/getPoolUseCase.ts
+++ b/src/useCases/pools/getPoolUseCase.ts
@@ -82,7 +82,17 @@ export class GetPoolUseCase {
 
     const participants = await this.poolsRepository.getPoolParticipants(poolId);
 
-    // Return structured response with additional metadata
+    // Use the mapper to construct response
+    return this.mapToResponse(pool, tournament, participants, isCreator, isParticipant);
+  }
+
+  private mapToResponse(
+    pool: any, // Replace with proper Pool type when available
+    tournament: any, // Replace with proper Tournament type when available
+    participants: any[], // Replace with proper Participant[] type when available
+    isCreator: boolean,
+    isParticipant: boolean
+  ): IGetPoolResponse {
     return {
       id: pool.id,
       name: pool.name,


### PR DESCRIPTION
…ethod

- Refactors the `GetPoolUseCase` to use a `mapToResponse` method for constructing the response.
- This improves code readability and maintainability by encapsulating the response structure creation.
- The `mapToResponse` method takes the pool, tournament, participants, isCreator, and isParticipant as arguments.
- Placeholder types are used for pool, tournament, and participants, to be replaced with proper types when available.