### PR TITLE
:recycle: refactor(pools): Use pool.participants directly in GetPoolUseCase

### DIFF
--- a/src/useCases/pools/getPoolUseCase.ts
+++ b/src/useCases/pools/getPoolUseCase.ts
@@ -80,7 +80,7 @@ export class GetPoolUseCase {
       throw new ResourceNotFoundError('Tournament not found');
     }
 
-    const participants = await this.poolsRepository.getPoolParticipants(poolId);
+    const participants = pool.participants;
 
     // Use the mapper to construct response
     return this.mapToResponse(pool, tournament, participants, isCreator, isParticipant);


### PR DESCRIPTION
- Directly uses `pool.participants` instead of calling `this.poolsRepository.getPoolParticipants(poolId)` in `GetPoolUseCase`.
- This simplifies the code and potentially improves performance by avoiding an unnecessary database query, assuming `participants` are already available within the `pool` object.
- Aligns with the ongoing refactoring efforts to streamline data access and improve code clarity.