### PR TITLE
:recycle: fix(pools): Allow joining pools by invite code and poolId

### DIFF
--- a/prisma/migrations/20250627094458_fix_pool_invitecode_unique/migration.sql
+++ b/prisma/migrations/20250627094458_fix_pool_invitecode_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "pools_inviteCode_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,7 +117,7 @@ model Pool {
   description          String?
   creatorId            String
   isPrivate            Boolean                  @default(false)
-  inviteCode           String?                  @unique
+  inviteCode           String?
   createdAt            DateTime                 @default(now())
   maxParticipants      Int?
   registrationDeadline DateTime?

--- a/src/http/controllers/pools/joinPoolController.spec.ts
+++ b/src/http/controllers/pools/joinPoolController.spec.ts
@@ -80,6 +80,7 @@ describe('Join Pool Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`)
       .send({
         inviteCode: pool.inviteCode,
+        poolId: pool.id, // Optional, but can be included
       });
 
     expect(response.statusCode).toEqual(200);
@@ -107,15 +108,28 @@ describe('Join Pool Controller (e2e)', async () => {
     expect(response.body).toHaveProperty('message');
   });
 
-  it('should return 404 when trying to join a pool with invalid invite code', async () => {
+  it('should return 401 when trying to join a pool with invalid invite code', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const owner = await createUser(usersRepository, {
+      email: 'some-other-guy@example.com',
+    });
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: owner.id,
+      tournamentId: tournament.id,
+      isPrivate: true,
+    });
+
     const response = await request(app.server)
       .post('/pools/join')
       .set('Authorization', `Bearer ${token}`)
       .send({
         inviteCode: 'invalid-invite-code',
+        poolId: pool.id,
       });
+    console.log(JSON.stringify(response, null, 2));
 
-    expect(response.statusCode).toEqual(404);
+    expect(response.statusCode).toEqual(401);
     expect(response.body).toHaveProperty('message');
   });
 

--- a/src/http/controllers/pools/joinPoolController.ts
+++ b/src/http/controllers/pools/joinPoolController.ts
@@ -5,14 +5,13 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
 export async function JoinPoolController(request: FastifyRequest, reply: FastifyReply) {
-  const joinPoolBodySchema = z
-    .object({
-      poolId: z.number().optional(),
-      inviteCode: z.string().optional(),
-    })
-    .refine((data) => data.poolId !== undefined || data.inviteCode !== undefined, {
-      message: 'Either poolId or inviteCode must be provided',
-    });
+  const joinPoolBodySchema = z.object({
+    poolId: z.number(),
+    inviteCode: z.string().optional(),
+  });
+  // .refine((data) => data.poolId !== undefined || data.inviteCode !== undefined, {
+  //   message: 'Either poolId or inviteCode must be provided',
+  // });
 
   try {
     const { poolId, inviteCode } = joinPoolBodySchema.parse(request.body);

--- a/src/repositories/pools/IPoolsRepository.ts
+++ b/src/repositories/pools/IPoolsRepository.ts
@@ -11,7 +11,7 @@ export interface IPoolsRepository {
   addParticipant(data: { poolId: number; userId: string }): Promise<void>;
   removeParticipant(data: { poolId: number; userId: string }): Promise<void>;
   findById(id: number): Promise<Pool | null>;
-  findByInviteCode(inviteCode: string): Promise<Pool | null>;
+  findByInviteCode(inviteCode: string, poolId: number): Promise<Pool | null>;
   findByCreatorId(creatorId: string): Promise<Pool[]>;
   findByParticipantId(userId: string): Promise<Pool[]>;
   getScoringRules(poolId: number): Promise<ScoringRule[]>;

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -272,7 +272,7 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
     return pool || null;
   }
 
-  async findByInviteCode(inviteCode: string): Promise<Pool | null> {
+  async findByInviteCode(inviteCode: string, poolId: number): Promise<Pool | null> {
     const pool = this.pools.find((pool) => pool.inviteCode === inviteCode);
     return pool || null;
   }

--- a/src/repositories/pools/PrismaPoolsRepository.ts
+++ b/src/repositories/pools/PrismaPoolsRepository.ts
@@ -71,9 +71,9 @@ export class PrismaPoolsRepository implements IPoolsRepository {
     return pool;
   }
 
-  async findByInviteCode(inviteCode: string) {
+  async findByInviteCode(inviteCode: string, poolId: number) {
     const pool = await prisma.pool.findUnique({
-      where: { inviteCode },
+      where: { id: poolId, inviteCode },
     });
 
     return pool;

--- a/src/test/mocks/pools.ts
+++ b/src/test/mocks/pools.ts
@@ -61,7 +61,7 @@ export async function createPoolWithParticipants(
   pool: Pool;
   participants: User[];
 }> {
-  const useraA = await createUser(repositories.usersRepository, {
+  const userA = await createUser(repositories.usersRepository, {
     fullName: 'John Doe',
     email: faker.internet.email(),
     passwordHash: 'hashed-password',
@@ -74,14 +74,14 @@ export async function createPoolWithParticipants(
   });
 
   const pool = await createPool(repositories.poolsRepository, {
-    creatorId: data.creatorId ?? useraA.id,
+    creatorId: data.creatorId ?? userA.id,
     ...data,
   });
 
   if (data.creatorId)
     await repositories.poolsRepository.addParticipant({
       poolId: pool.id,
-      userId: useraA.id,
+      userId: userA.id,
     });
 
   await repositories.poolsRepository.addParticipant({
@@ -91,6 +91,6 @@ export async function createPoolWithParticipants(
 
   return {
     pool,
-    participants: [useraA, userB],
+    participants: [userA, userB],
   };
 }

--- a/src/useCases/pools/joinPoolUseCase.ts
+++ b/src/useCases/pools/joinPoolUseCase.ts
@@ -28,7 +28,7 @@ export class JoinPoolUseCase {
     if (poolId) {
       pool = await this.poolsRepository.findById(poolId);
     } else if (inviteCode) {
-      pool = await this.poolsRepository.findByInviteCode(inviteCode);
+      pool = await this.poolsRepository.findByInviteCode(inviteCode, poolId!);
     } else {
       throw new ResourceNotFoundError('Either poolId or inviteCode must be provided');
     }


### PR DESCRIPTION
- Modified the `JoinPoolController` to accept both `poolId` and `inviteCode` in the request body.
- Updated the `JoinPoolUseCase` to use `poolId` when available, and fall back to `inviteCode` if `poolId` is not provided.
- Modified `IPoolsRepository`, `InMemoryPoolsRepository`, and `PrismaPoolsRepository` to accept `poolId` when searching by invite code.
- Removed the `unique` constraint from the `inviteCode` field in the `Pool` model in `prisma/schema.prisma`.
- Added a migration to remove the unique index on `inviteCode`.
- Updated the `joinPoolController.spec.ts` to include `poolId` in the request body.
- Updated the `joinPoolController.spec.ts` to return 401 when trying to join a pool with an invalid invite code.
- Updated the `createPoolWithParticipants` mock to use `userA` instead of `useraA`.