### PR TITLE
Add Swagger documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",
     "fastify": "^5.2.1",
+    "@fastify/swagger": "^8.0.1",
+    "@fastify/swagger-ui": "^2.0.3",
     "npm-run-all": "^4.1.5",
     "prisma": "^6.4.1",
     "zod": "^3.24.2"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,7 @@
 import cors from '@fastify/cors';
 import fastifyJwt from '@fastify/jwt';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
 import fastify, { FastifyInstance } from 'fastify';
 import { ZodError } from 'zod';
 import { env } from './env/config';
@@ -30,6 +32,21 @@ export const createServer = async (): Promise<FastifyInstance> => {
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
     credentials: true,
   });
+
+  if (env.NODE_ENV !== 'test') {
+    await server.register(swagger, {
+      openapi: {
+        info: {
+          title: env.THE_APP_NAME,
+          version: env.THE_APP_VERSION,
+        },
+      },
+    });
+
+    await server.register(swaggerUi, {
+      routePrefix: '/docs',
+    });
+  }
 
   // Register custom decorators
   //server.decorateRequest('user', null);


### PR DESCRIPTION
## Summary
- include `@fastify/swagger` and `@fastify/swagger-ui` deps
- register Swagger UI at `/docs` when not in test env

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a594bc908328919eda671054e98d