### PR TITLE
Add JSON schemas and route validation

### DIFF
--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -1,5 +1,12 @@
 import { verifyJwt } from '@/http/middlewares/verifyJWT';
 import { FastifyInstance } from 'fastify';
+import {
+  errorResponseSchema,
+  matchIdParam,
+  matchSchema,
+  predictionSchema,
+  updateMatchBody,
+} from '../schemas';
 import { getMatchController } from '../controllers/matches/getMatchController';
 import { getMatchPredictions } from '../controllers/matches/getMatchPredictionsController';
 import { updateMatchController } from '../controllers/matches/updateMatchController';
@@ -7,7 +14,49 @@ import { updateMatchController } from '../controllers/matches/updateMatchControl
 export async function matchesRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
-  app.get('/matches/:matchId', getMatchController);
-  app.get('/matches/:matchId/predictions', getMatchPredictions);
-  app.put('/matches/:matchId', updateMatchController);
+  app.get(
+    '/matches/:matchId',
+    {
+      schema: {
+        params: matchIdParam,
+        response: {
+          200: { type: 'object', properties: { match: matchSchema } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getMatchController,
+  );
+  app.get(
+    '/matches/:matchId/predictions',
+    {
+      schema: {
+        params: matchIdParam,
+        response: {
+          200: {
+            type: 'object',
+            properties: { predictions: { type: 'array', items: predictionSchema } },
+          },
+          404: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    getMatchPredictions,
+  );
+  app.put(
+    '/matches/:matchId',
+    {
+      schema: {
+        params: matchIdParam,
+        body: updateMatchBody,
+        response: {
+          200: { type: 'object', properties: { match: matchSchema } },
+          404: errorResponseSchema,
+          400: errorResponseSchema,
+        },
+      },
+    },
+    updateMatchController,
+  );
 }

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -1,4 +1,15 @@
 import { FastifyInstance } from 'fastify';
+import {
+  createPoolBody,
+  errorResponseSchema,
+  poolIdParam,
+  poolSchema,
+  poolStandingSchema,
+  updatePoolBody,
+  userIdParam,
+  userSchema,
+  predictionSchema,
+} from '../schemas';
 import { createPoolController } from '../controllers/pools/createPoolController';
 import { getPoolController } from '../controllers/pools/getPoolController';
 import { getPoolPredictionsController } from '../controllers/pools/getPoolPredictionsController';
@@ -13,13 +24,125 @@ import { verifyJwt } from '../middlewares/verifyJWT';
 export async function PoolRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
-  app.post('/pools', createPoolController);
-  app.get('/pools/:poolId', getPoolController);
-  app.post('/pools/join', JoinPoolController);
-  app.post('/pools/:poolId/leave', leavePoolController);
-  app.delete('/pools/:poolId/users/:userId', removeUserFromPoolController);
-  app.get('/pools/:poolId/users', getPoolUsersController);
-  app.put('/pools/:poolId', updatePoolController);
-  app.get('/pools/:poolId/predictions', getPoolPredictionsController);
-  app.get('/pools/:poolId/standings', getPoolStandingsController);
+  app.post(
+    '/pools',
+    {
+      schema: {
+        body: createPoolBody,
+        response: {
+          201: { type: 'object', properties: { pool: poolSchema } },
+          409: errorResponseSchema,
+          404: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    createPoolController,
+  );
+  app.get(
+    '/pools/:poolId',
+    {
+      schema: {
+        params: poolIdParam,
+        response: {
+          200: { type: 'object', properties: { pool: poolSchema } },
+          404: errorResponseSchema,
+          403: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    getPoolController,
+  );
+  app.post(
+    '/pools/join',
+    {
+      schema: {
+        body: poolIdParam,
+        response: { 200: { type: 'object', properties: { pool: poolSchema } }, 404: errorResponseSchema, 403: errorResponseSchema },
+      },
+    },
+    JoinPoolController,
+  );
+  app.post(
+    '/pools/:poolId/leave',
+    {
+      schema: {
+        params: poolIdParam,
+        response: { 200: { type: 'object', properties: { message: { type: 'string' } } }, 404: errorResponseSchema },
+      },
+    },
+    leavePoolController,
+  );
+  app.delete(
+    '/pools/:poolId/users/:userId',
+    {
+      schema: {
+        params: {
+          type: 'object',
+          properties: {
+            poolId: { type: 'string' },
+            userId: { type: 'string' },
+          },
+          required: ['poolId', 'userId'],
+        },
+        response: { 200: { type: 'object', properties: { message: { type: 'string' } } }, 404: errorResponseSchema },
+      },
+    },
+    removeUserFromPoolController,
+  );
+  app.get(
+    '/pools/:poolId/users',
+    {
+      schema: {
+        params: poolIdParam,
+        response: {
+          200: { type: 'object', properties: { users: { type: 'array', items: userSchema } } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getPoolUsersController,
+  );
+  app.put(
+    '/pools/:poolId',
+    {
+      schema: {
+        params: poolIdParam,
+        body: updatePoolBody,
+        response: {
+          200: { type: 'object', properties: { pool: poolSchema } },
+          404: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    updatePoolController,
+  );
+  app.get(
+    '/pools/:poolId/predictions',
+    {
+      schema: {
+        params: poolIdParam,
+        response: {
+          200: { type: 'object', properties: { predictions: { type: 'array', items: predictionSchema } } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getPoolPredictionsController,
+  );
+  app.get(
+    '/pools/:poolId/standings',
+    {
+      schema: {
+        params: poolIdParam,
+        response: {
+          200: { type: 'object', properties: { standings: { type: 'array', items: poolStandingSchema } } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getPoolStandingsController,
+  );
 }

--- a/src/http/routes/predictions.routes.ts
+++ b/src/http/routes/predictions.routes.ts
@@ -1,5 +1,12 @@
 import { verifyJwt } from '@/http/middlewares/verifyJWT';
 import { FastifyInstance } from 'fastify';
+import {
+  createPredictionBody,
+  errorResponseSchema,
+  predictionIdParam,
+  predictionSchema,
+  updatePredictionBody,
+} from '../schemas';
 import { createPredictionController } from '../controllers/predictions/createPredictionController';
 import { getPredictionController } from '../controllers/predictions/getPredictionController';
 import { updatePredictionController } from '../controllers/predictions/updatePredictionController';
@@ -7,7 +14,53 @@ import { updatePredictionController } from '../controllers/predictions/updatePre
 export async function PredictionsRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
-  app.post('/predictions', createPredictionController);
-  app.get('/predictions/:predictionId', getPredictionController);
-  app.put('/predictions/:predictionId', updatePredictionController);
+  app.post(
+    '/predictions',
+    {
+      schema: {
+        body: createPredictionBody,
+        response: {
+          201: { type: 'object', properties: { prediction: predictionSchema } },
+          404: errorResponseSchema,
+          403: errorResponseSchema,
+          400: errorResponseSchema,
+          409: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    createPredictionController,
+  );
+  app.get(
+    '/predictions/:predictionId',
+    {
+      schema: {
+        params: predictionIdParam,
+        response: {
+          200: { type: 'object', properties: { prediction: predictionSchema } },
+          404: errorResponseSchema,
+          403: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    getPredictionController,
+  );
+  app.put(
+    '/predictions/:predictionId',
+    {
+      schema: {
+        params: predictionIdParam,
+        body: updatePredictionBody,
+        response: {
+          200: { type: 'object', properties: { prediction: predictionSchema } },
+          404: errorResponseSchema,
+          403: errorResponseSchema,
+          400: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    updatePredictionController,
+  );
 }

--- a/src/http/routes/tournaments.routes.ts
+++ b/src/http/routes/tournaments.routes.ts
@@ -1,11 +1,39 @@
 import { verifyJwt } from '@/http/middlewares/verifyJWT';
 import { FastifyInstance } from 'fastify';
+import {
+  errorResponseSchema,
+  matchSchema,
+  tournamentSchema,
+  matchIdParam,
+} from '../schemas';
 import { listTournamentsController } from '../controllers/tournaments/listTournamentsController';
 import { getTournamentMatchesController } from '../controllers/tournaments/getTournamentMatchesController';
 
 export async function tournamentsRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
-  app.get('/tournaments', listTournamentsController);
-  app.get('/tournaments/:tournamentId/matches', getTournamentMatchesController);
+  app.get(
+    '/tournaments',
+    {
+      schema: {
+        response: {
+          200: { type: 'object', properties: { tournaments: { type: 'array', items: tournamentSchema } } },
+        },
+      },
+    },
+    listTournamentsController,
+  );
+  app.get(
+    '/tournaments/:tournamentId/matches',
+    {
+      schema: {
+        params: { type: 'object', properties: { tournamentId: { type: 'string' } }, required: ['tournamentId'] },
+        response: {
+          200: { type: 'object', properties: { matches: { type: 'array', items: matchSchema } } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getTournamentMatchesController,
+  );
 }

--- a/src/http/routes/user.routes.ts
+++ b/src/http/routes/user.routes.ts
@@ -1,4 +1,11 @@
 import { FastifyInstance } from 'fastify';
+import {
+  createUserBody,
+  errorResponseSchema,
+  updateUserBody,
+  userIdParam,
+  userSchema,
+} from '../schemas';
 import { CreateUserController } from '../controllers/user/createUserController';
 import { GetLoggedUserInfoController } from '../controllers/user/getLoggedUserInfoController';
 import { GetUserInfoController } from '../controllers/user/getUserInfoController';
@@ -11,11 +18,107 @@ import { verifyJwt } from '../middlewares/verifyJWT';
 export async function UserRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifyJwt);
 
-  app.post('/users', CreateUserController);
-  app.put('/users/:userId', UpdateUserController);
-  app.get('/users/:userId', GetUserInfoController);
-  app.get('/users/me', GetLoggedUserInfoController);
-  app.get('/users/:userId/pools', getUserPoolsController);
-  app.get('/users/me/predictions', getUserPredictionsController);
-  app.get('/users/me/pools/standings', getUserPoolsStandingsController);
+  app.post(
+    '/users',
+    {
+      schema: {
+        body: createUserBody,
+        response: {
+          201: { type: 'object', properties: { user: userSchema } },
+          409: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    CreateUserController,
+  );
+
+  app.put(
+    '/users/:userId',
+    {
+      schema: {
+        params: userIdParam,
+        body: updateUserBody,
+        response: {
+          200: { type: 'object', properties: { user: userSchema } },
+          404: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    UpdateUserController,
+  );
+
+  app.get(
+    '/users/:userId',
+    {
+      schema: {
+        params: userIdParam,
+        response: {
+          200: { type: 'object', properties: { user: userSchema } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    GetUserInfoController,
+  );
+
+  app.get(
+    '/users/me',
+    {
+      schema: {
+        response: {
+          200: { type: 'object', properties: { user: userSchema } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    GetLoggedUserInfoController,
+  );
+  app.get(
+    '/users/:userId/pools',
+    {
+      schema: {
+        params: userIdParam,
+        response: {
+          200: {
+            type: 'object',
+            properties: { pools: { type: 'array', items: poolSchema } },
+          },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getUserPoolsController,
+  );
+  app.get(
+    '/users/me/predictions',
+    {
+      schema: {
+        querystring: poolIdQuery,
+        response: {
+          200: {
+            type: 'object',
+            properties: { predictions: { type: 'array', items: predictionSchema } },
+          },
+          404: errorResponseSchema,
+          403: errorResponseSchema,
+          422: errorResponseSchema,
+        },
+      },
+    },
+    getUserPredictionsController,
+  );
+  app.get(
+    '/users/me/pools/standings',
+    {
+      schema: {
+        response: {
+          200: { type: 'object', properties: { standing: { type: 'array', items: poolStandingSchema } } },
+          404: errorResponseSchema,
+        },
+      },
+    },
+    getUserPoolsStandingsController,
+  );
 }

--- a/src/http/schemas/index.ts
+++ b/src/http/schemas/index.ts
@@ -1,0 +1,255 @@
+export const errorResponseSchema = {
+  type: 'object',
+  properties: {
+    message: { type: 'string' },
+  },
+  required: ['message'],
+};
+
+export const userSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    fullName: { type: 'string' },
+    email: { type: 'string' },
+    profileImageUrl: { type: 'string', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'fullName', 'email', 'createdAt'],
+};
+
+export const poolSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    tournamentId: { type: 'integer' },
+    name: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    creatorId: { type: 'string' },
+    isPrivate: { type: 'boolean' },
+    inviteCode: { type: 'string', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    maxParticipants: { type: 'integer', nullable: true },
+    registrationDeadline: { type: 'string', format: 'date-time', nullable: true },
+  },
+  required: ['id', 'tournamentId', 'name', 'creatorId', 'isPrivate', 'createdAt'],
+};
+
+export const matchSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    tournamentId: { type: 'integer' },
+    homeTeamId: { type: 'integer' },
+    awayTeamId: { type: 'integer' },
+    matchDatetime: { type: 'string', format: 'date-time' },
+    stadium: { type: 'string', nullable: true },
+    stage: { type: 'string' },
+    group: { type: 'string', nullable: true },
+    homeTeamScore: { type: 'integer', nullable: true },
+    awayTeamScore: { type: 'integer', nullable: true },
+    matchStatus: { type: 'string' },
+    hasExtraTime: { type: 'boolean' },
+    hasPenalties: { type: 'boolean' },
+    penaltyHomeScore: { type: 'integer', nullable: true },
+    penaltyAwayScore: { type: 'integer', nullable: true },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time', nullable: true },
+  },
+  required: ['id', 'tournamentId', 'homeTeamId', 'awayTeamId', 'matchDatetime', 'stage', 'matchStatus', 'hasExtraTime', 'hasPenalties', 'createdAt'],
+};
+
+export const predictionSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    poolId: { type: 'integer' },
+    matchId: { type: 'integer' },
+    userId: { type: 'string' },
+    predictedHomeScore: { type: 'integer' },
+    predictedAwayScore: { type: 'integer' },
+    predictedHasExtraTime: { type: 'boolean' },
+    predictedHasPenalties: { type: 'boolean' },
+    predictedPenaltyHomeScore: { type: 'integer', nullable: true },
+    predictedPenaltyAwayScore: { type: 'integer', nullable: true },
+    submittedAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time', nullable: true },
+    pointsEarned: { type: 'integer', nullable: true },
+  },
+  required: [
+    'id',
+    'poolId',
+    'matchId',
+    'userId',
+    'predictedHomeScore',
+    'predictedAwayScore',
+    'predictedHasExtraTime',
+    'predictedHasPenalties',
+    'submittedAt',
+  ],
+};
+
+export const tournamentSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    name: { type: 'string' },
+    startDate: { type: 'string', format: 'date-time' },
+    endDate: { type: 'string', format: 'date-time' },
+    logoUrl: { type: 'string', nullable: true },
+    status: { type: 'string' },
+    createdAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'name', 'startDate', 'endDate', 'status', 'createdAt'],
+};
+
+export const userIdParam = {
+  type: 'object',
+  properties: { userId: { type: 'string' } },
+  required: ['userId'],
+};
+
+export const matchIdParam = {
+  type: 'object',
+  properties: { matchId: { type: 'string' } },
+  required: ['matchId'],
+};
+
+export const poolIdParam = {
+  type: 'object',
+  properties: { poolId: { type: 'string' } },
+  required: ['poolId'],
+};
+
+export const predictionIdParam = {
+  type: 'object',
+  properties: { predictionId: { type: 'string' } },
+  required: ['predictionId'],
+};
+
+export const poolIdQuery = {
+  type: 'object',
+  properties: { poolId: { type: 'integer' } },
+};
+
+export const createUserBody = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    email: { type: 'string' },
+    passwordHash: { type: 'string' },
+    fullName: { type: 'string' },
+    profileImageUrl: { type: 'string' },
+  },
+  required: ['email', 'passwordHash', 'fullName', 'profileImageUrl'],
+};
+
+export const updateUserBody = {
+  type: 'object',
+  properties: {
+    email: { type: 'string' },
+    fullName: { type: 'string' },
+    profileImageUrl: { type: 'string' },
+  },
+};
+
+export const updateMatchBody = {
+  type: 'object',
+  properties: {
+    homeTeam: { type: 'integer' },
+    awayTeam: { type: 'integer' },
+    homeScore: { type: 'integer' },
+    awayScore: { type: 'integer' },
+    matchDate: { type: 'string' },
+    matchStatus: { type: 'string' },
+    matchStage: { type: 'string' },
+    hasExtraTime: { type: 'boolean' },
+    hasPenalties: { type: 'boolean' },
+    penaltyHomeScore: { type: 'integer' },
+    penaltyAwayScore: { type: 'integer' },
+    stadium: { type: 'string' },
+  },
+};
+
+export const createPredictionBody = {
+  type: 'object',
+  properties: {
+    matchId: { type: 'integer' },
+    poolId: { type: 'integer' },
+    predictedHomeScore: { type: 'integer' },
+    predictedAwayScore: { type: 'integer' },
+    predictedHasExtraTime: { type: 'boolean' },
+    predictedHasPenalties: { type: 'boolean' },
+    predictedPenaltyHomeScore: { type: 'integer' },
+    predictedPenaltyAwayScore: { type: 'integer' },
+  },
+  required: ['matchId', 'poolId', 'predictedHomeScore', 'predictedAwayScore'],
+};
+
+export const updatePredictionBody = {
+  type: 'object',
+  properties: {
+    predictedHomeScore: { type: 'integer' },
+    predictedAwayScore: { type: 'integer' },
+    predictedHasExtraTime: { type: 'boolean' },
+    predictedHasPenalties: { type: 'boolean' },
+    predictedPenaltyHomeScore: { type: 'integer' },
+    predictedPenaltyAwayScore: { type: 'integer' },
+  },
+};
+
+export const createPoolBody = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    description: { type: 'string' },
+    tournamentId: { type: 'integer' },
+    isPrivate: { type: 'boolean' },
+    maxParticipants: { type: 'integer' },
+    inviteCode: { type: 'string' },
+    registrationDeadline: { type: 'string', format: 'date-time' },
+  },
+  required: ['name', 'tournamentId'],
+};
+
+export const updatePoolBody = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    description: { type: 'string' },
+    isPrivate: { type: 'boolean' },
+    maxParticipants: { type: 'integer' },
+    inviteCode: { type: 'string' },
+    registrationDeadline: { type: 'string', format: 'date-time' },
+  },
+};
+
+export const poolStandingSchema = {
+  type: 'object',
+  properties: {
+    ranking: { type: 'integer' },
+    fullName: { type: 'string' },
+    profileImageUrl: { type: 'string', nullable: true },
+    userId: { type: 'string' },
+    poolId: { type: 'integer' },
+    totalPredictions: { type: 'integer' },
+    totalPoints: { type: 'integer' },
+    exactScoreCount: { type: 'integer' },
+    pointsRatio: { type: 'number' },
+    guessRatio: { type: 'number' },
+    predictionsRatio: { type: 'number' },
+  },
+  required: [
+    'ranking',
+    'fullName',
+    'userId',
+    'poolId',
+    'totalPredictions',
+    'totalPoints',
+    'exactScoreCount',
+    'pointsRatio',
+    'guessRatio',
+    'predictionsRatio',
+  ],
+};
+


### PR DESCRIPTION
## Summary
- define JSON Schema objects for API resources and request elements
- apply schema validation on users, matches, pools, predictions and tournaments routes

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6863a81f36b083289c6736e7adf2ac5a