### PR TITLE
refactor: reuse pool response schemas

### DIFF
--- a/src/http/controllers/user/getLoggedUserController.spec.ts
+++ b/src/http/controllers/user/getLoggedUserController.spec.ts
@@ -1,9 +1,9 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it, test } from 'vitest';
+
 import { createServer } from '@/app';
 import { env } from '@/env/config';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
-import { it } from 'node:test';
-import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 describe('Get User Info (e2e)', async () => {
   const app = await createServer();
@@ -19,7 +19,7 @@ describe('Get User Info (e2e)', async () => {
     await app.close();
   });
 
-  test('should return user info', async () => {
+  it('should return user info', async () => {
     const response = await request(app.server)
       .get(`/users/me`)
       .set('Authorization', `Bearer ${token}`)

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -27,10 +27,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           201: {
             description: 'Pool created successfully',
-            type: 'object',
-            properties: {
-              pool: poolSchemas.Pool,
-            },
+            ...poolSchemas.CreatePoolResponse,
           },
           422: {
             description: 'Validation error',
@@ -57,10 +54,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Pool information retrieved successfully',
-            type: 'object',
-            properties: {
-              pool: poolSchemas.Pool,
-            },
+            ...poolSchemas.GetPoolResponse,
           },
           404: {
             description: 'Pool not found',
@@ -88,10 +82,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Successfully joined the pool',
-            type: 'object',
-            properties: {
-              pool: poolSchemas.Pool,
-            },
+            ...poolSchemas.JoinPoolResponse,
           },
           401: {
             description: 'Unauthorized - Private pool or invalid access',
@@ -101,11 +92,8 @@ export function PoolRoutes(app: FastifyInstance): void {
             },
           },
           404: {
-            description: 'Pool or user not found',
-            type: 'object',
-            properties: {
-              message: { type: 'string' },
-            },
+            description: 'Pool not found',
+            ...poolSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -133,24 +121,15 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Successfully joined the pool',
-            type: 'object',
-            properties: {
-              pool: poolSchemas.Pool,
-            },
+            ...poolSchemas.JoinPoolResponse,
           },
           401: {
             description: 'Unauthorized - Invalid invite code',
-            type: 'object',
-            properties: {
-              message: { type: 'string' },
-            },
+            ...poolSchemas.InvalidPoolCodeError,
           },
           404: {
-            description: 'Pool not found with this invite code',
-            type: 'object',
-            properties: {
-              message: { type: 'string' },
-            },
+            description: 'Pool not found',
+            ...poolSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -252,14 +231,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Pool users retrieved successfully',
-            type: 'object',
-            properties: {
-              users: {
-                type: 'array',
-                items: poolSchemas.PoolUser,
-              },
-              count: { type: 'number' },
-            },
+            ...poolSchemas.GetPoolUsersResponse,
           },
           403: {
             description: 'User is not a member of this pool',
@@ -291,10 +263,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Pool updated successfully',
-            type: 'object',
-            properties: {
-              pool: poolSchemas.Pool,
-            },
+            ...poolSchemas.UpdatePoolResponse,
           },
           403: {
             description: 'Only pool owner can update the pool',
@@ -329,13 +298,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Pool predictions retrieved successfully',
-            type: 'object',
-            properties: {
-              predictions: {
-                type: 'array',
-                items: poolSchemas.PoolPrediction,
-              },
-            },
+            ...poolSchemas.GetPoolPredictionsResponse,
           },
           403: {
             description: 'User is not a member of this pool',
@@ -370,21 +333,7 @@ export function PoolRoutes(app: FastifyInstance): void {
         response: {
           200: {
             description: 'Pool standings retrieved successfully',
-            type: 'object',
-            properties: {
-              standings: {
-                type: 'array',
-                items: poolSchemas.PoolStanding,
-              },
-              poolInfo: {
-                type: 'object',
-                properties: {
-                  id: { type: 'number' },
-                  title: { type: 'string' },
-                  participantCount: { type: 'number' },
-                },
-              },
-            },
+            ...poolSchemas.GetPoolStandingsResponse,
           },
           403: {
             description: 'User is not a member of this pool',


### PR DESCRIPTION
## Summary
- simplify pool routes by spreading existing response schemas
- centralize pool error definitions for invite code and not found cases

## Testing
- `npm run lint` *(fails: import/order issues in unrelated files)*
- `npx eslint src/http/routes/pools.routes.ts src/http/schemas/pool.schemas.ts`
- `npm run test:run`
- `npm run test:e2e` *(fails: invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689c6176d2f88328a84dee1502511c4b