### PR TITLE
refactor: rename controllers

### DIFF
--- a/src/http/controllers/matches/getMatchPredictionsController.ts
+++ b/src/http/controllers/matches/getMatchPredictionsController.ts
@@ -9,7 +9,7 @@ interface GetMatchPredictionsParams {
   matchId: number;
 }
 
-export async function getMatchPredictions(
+export async function getMatchPredictionsController(
   request: FastifyRequest<{ Params: GetMatchPredictionsParams }>,
   reply: FastifyReply
 ): Promise<FastifyReply> {

--- a/src/http/controllers/user/getLoggedUserInfoController.ts
+++ b/src/http/controllers/user/getLoggedUserInfoController.ts
@@ -1,8 +1,12 @@
-import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
-import { makeGetUserInfoUseCase } from '@/useCases/users/factory/makeGetUserInfoUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
 
-export async function GetLoggedUserInfoController(request: FastifyRequest, reply: FastifyReply) {
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { makeGetUserInfoUseCase } from '@/useCases/users/factory/makeGetUserInfoUseCase';
+
+export async function getLoggedUserInfoController(
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<FastifyReply> {
   const userId = request.user.sub;
 
   try {

--- a/src/http/controllers/user/getUserInfoController.ts
+++ b/src/http/controllers/user/getUserInfoController.ts
@@ -1,14 +1,15 @@
-import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
-import { makeGetUserInfoUseCase } from '@/useCases/users/factory/makeGetUserInfoUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
-export async function GetUserInfoController(
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { makeGetUserInfoUseCase } from '@/useCases/users/factory/makeGetUserInfoUseCase';
+
+export async function getUserInfoController(
   request: FastifyRequest<{
     Params: { userId: string };
   }>,
   reply: FastifyReply
-) {
+): Promise<FastifyReply> {
   const getUserParamsSchema = z.object({
     userId: z.string(), //.cuid(),
   });

--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -4,7 +4,7 @@ import { verifyJwt } from '@/http/middlewares/verifyJWT';
 import { matchSchemas } from '@/http/schemas/match.schemas';
 
 import { getMatchController } from '../controllers/matches/getMatchController';
-import { getMatchPredictions } from '../controllers/matches/getMatchPredictionsController';
+import { getMatchPredictionsController } from '../controllers/matches/getMatchPredictionsController';
 import { updateMatchController } from '../controllers/matches/updateMatchController';
 
 export function matchesRoutes(app: FastifyInstance): void {
@@ -79,7 +79,7 @@ export function matchesRoutes(app: FastifyInstance): void {
         },
       },
     },
-    getMatchPredictions
+    getMatchPredictionsController
   );
 
   app.put(

--- a/src/http/routes/user.routes.ts
+++ b/src/http/routes/user.routes.ts
@@ -1,8 +1,8 @@
 import { FastifyInstance } from 'fastify';
 
 import { createUserController } from '../controllers/user/createUserController';
-import { GetLoggedUserInfoController } from '../controllers/user/getLoggedUserInfoController';
-import { GetUserInfoController } from '../controllers/user/getUserInfoController';
+import { getLoggedUserInfoController } from '../controllers/user/getLoggedUserInfoController';
+import { getUserInfoController } from '../controllers/user/getUserInfoController';
 import { getUserPoolsController } from '../controllers/user/getUserPoolsController';
 import { getUserPoolsStandingsController } from '../controllers/user/getUserPoolsStandingsController';
 import { getUserPredictionsController } from '../controllers/user/getUserPredictionsController';
@@ -103,7 +103,7 @@ export function UserRoutes(app: FastifyInstance): void {
         },
       },
     },
-    GetUserInfoController
+    getUserInfoController
   );
 
   app.get(
@@ -132,7 +132,7 @@ export function UserRoutes(app: FastifyInstance): void {
         },
       },
     },
-    GetLoggedUserInfoController
+    getLoggedUserInfoController
   );
 
   // Public route to list pools for a user


### PR DESCRIPTION
## Summary
- rename user info and match prediction controllers
- update routes for new controller names

## Testing
- `npm run lint` *(fails: import order errors)*
- `npx eslint src/http/controllers/user/getUserInfoController.ts src/http/controllers/user/getLoggedUserInfoController.ts src/http/controllers/matches/getMatchPredictionsController.ts src/http/routes/user.routes.ts src/http/routes/matches.routes.ts`
- `npm run test:run`
- `npm run test:e2e` *(fails: invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a052268d6c8328b2bb7799369fddf6