### PR TITLE
Use name instead of title for pool schema fields

### DIFF
--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -402,7 +402,7 @@ export function poolRoutes(app: FastifyInstance): void {
                 type: 'object',
                 properties: {
                   id: { type: 'number' },
-                  title: { type: 'string' },
+                  name: { type: 'string' },
                   participantCount: { type: 'number' },
                 },
               },

--- a/src/http/schemas/pool.schemas.ts
+++ b/src/http/schemas/pool.schemas.ts
@@ -386,7 +386,7 @@ export const poolSchemas = {
         type: 'object',
         properties: {
           id: { type: 'number' },
-          title: { type: 'string' },
+          name: { type: 'string' },
           participantCount: { type: 'number' },
         },
       },

--- a/src/http/schemas/user.schemas.ts
+++ b/src/http/schemas/user.schemas.ts
@@ -110,7 +110,7 @@ export const userSchemas = {
     type: 'object',
     properties: {
       id: { type: 'number', description: 'Pool unique identifier' },
-      title: { type: 'string', description: 'Pool title' },
+      name: { type: 'string', description: 'Pool name' },
       code: { type: 'string', description: 'Pool invitation code' },
       ownerId: { type: 'string', description: 'Pool owner user ID' },
       createdAt: { type: 'string', format: 'date-time' },


### PR DESCRIPTION
## Summary
- replace pool `title` field with `name` in user pool schema
- rename standings response `poolInfo.title` to `poolInfo.name`
- update pool standings schema to use `name`

## Testing
- `npm run lint` *(fails: import order, missing return types, and other lint errors)*
- `npm run test:run`
- `npm run test:e2e` *(fails: invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a589d5db8083288f3aa41079414e2f