### PR TITLE
refactor: unify schema $ref style

### DIFF
--- a/src/http/schemas/pool.schemas.ts
+++ b/src/http/schemas/pool.schemas.ts
@@ -129,7 +129,7 @@ export const poolSchemas = {
   CreatePoolResponse: {
     type: 'object',
     properties: {
-      pool: { $ref: '#/components/schemas/Pool' },
+      pool: { $ref: 'Pool#' },
     },
   },
 
@@ -150,7 +150,7 @@ export const poolSchemas = {
   GetPoolResponse: {
     type: 'object',
     properties: {
-      pool: { $ref: '#/components/schemas/Pool' },
+      pool: { $ref: 'Pool#' },
     },
   },
 
@@ -184,7 +184,7 @@ export const poolSchemas = {
   JoinPoolResponse: {
     type: 'object',
     properties: {
-      pool: { $ref: '#/components/schemas/Pool' },
+      pool: { $ref: 'Pool#' },
     },
   },
 
@@ -247,7 +247,7 @@ export const poolSchemas = {
     properties: {
       users: {
         type: 'array',
-        items: { $ref: '#/components/schemas/PoolUser' },
+        items: { $ref: 'PoolUser#' },
       },
       count: { type: 'number', description: 'Total number of users in the pool' },
     },
@@ -293,7 +293,7 @@ export const poolSchemas = {
   UpdatePoolResponse: {
     type: 'object',
     properties: {
-      pool: { $ref: '#/components/schemas/Pool' },
+      pool: { $ref: 'Pool#' },
     },
   },
 
@@ -354,7 +354,7 @@ export const poolSchemas = {
     properties: {
       predictions: {
         type: 'array',
-        items: { $ref: '#/components/schemas/PoolPrediction' },
+        items: { $ref: 'PoolPrediction#' },
       },
     },
   },
@@ -380,7 +380,7 @@ export const poolSchemas = {
     properties: {
       standings: {
         type: 'array',
-        items: { $ref: '#/components/schemas/PoolStanding' },
+        items: { $ref: 'PoolStanding#' },
       },
       poolInfo: {
         type: 'object',

--- a/src/http/schemas/user.schemas.ts
+++ b/src/http/schemas/user.schemas.ts
@@ -80,7 +80,7 @@ export const userSchemas = {
   UpdateUserResponse: {
     type: 'object',
     properties: {
-      user: { $ref: '#/components/schemas/User' },
+      user: { $ref: 'User#' },
     },
   },
 
@@ -88,7 +88,7 @@ export const userSchemas = {
   GetUserInfoResponse: {
     type: 'object',
     properties: {
-      user: { $ref: '#/components/schemas/User' },
+      user: { $ref: 'User#' },
     },
   },
 
@@ -125,7 +125,7 @@ export const userSchemas = {
     properties: {
       pools: {
         type: 'array',
-        items: { $ref: '#/components/schemas/UserPool' },
+        items: { $ref: 'UserPool#' },
       },
     },
   },
@@ -189,7 +189,7 @@ export const userSchemas = {
     properties: {
       predictions: {
         type: 'array',
-        items: { $ref: '#/components/schemas/Prediction' },
+        items: { $ref: 'Prediction#' },
       },
     },
   },
@@ -227,7 +227,7 @@ export const userSchemas = {
     properties: {
       standing: {
         type: 'array',
-        items: { $ref: '#/components/schemas/Standing' },
+        items: { $ref: 'Standing#' },
       },
     },
   },


### PR DESCRIPTION
## Summary
- standardize JSON schema references on `SchemaName#` style in user and pool schemas

## Testing
- `npm run lint` *(fails: There should be at least one empty line between import groups)*
- `npm run test:run`
- `npm run test:e2e` *(fails: invalid environment variables)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58d58fa708328b7d5d9bf454da0b5