### PR TITLE
docs: clarify seeding and data access rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,10 @@
 
 - **Dev**: `npm run dev` (watch mode with tsx)
 - **Build**: `npm run build` (tsup)
-- **Test Unit**: `npm run test:run` or `vitest` (src/useCases/\*_/_.spec.ts)
-- **Test E2E**: `npm run test:e2e` (src/http/\*_/_.spec.ts)
-- **Test Single Unit**: `npm run test:run --  path/to/test.spec.ts`
+- **Seed**: `npx prisma db seed` (preloads World Cup teams, tournaments, and matches)
+- **Test Unit**: `npm run test:run` or `vitest` (src/useCases/*/*.spec.ts)
+- **Test E2E**: `npm run test:e2e` (src/http/*/*.spec.ts)
+- **Test Single Unit**: `npm run test:run -- path/to/test.spec.ts`
 - **Test Single E2E**: `npm run test:e2e -- path/to/test.spec.ts`
 - **Lint**: `npm run lint` / `npm run lint:fix`
 - **Coverage**: `npm run test:coverage` / `npm run test:e2e:coverage`
@@ -20,6 +21,11 @@
 - **Structure**: Clean Architecture (useCases, repositories, controllers)
 - **Paths**: `@/*` alias maps to `src/*`
 
+## Data
+
+- **Read-only**: teams, tournaments, and matches are immutable for regular users
+- **Admin**: only admin routes may update match records
+
 ## Code Conventions
 
 - **Imports**: External libs first, then internal with `@/` prefix, alphabetized with newlines between groups
@@ -31,3 +37,8 @@
 - **Error Handling**: Custom error classes (ResourceNotFoundError, NotParticipantError), Zod validation errors
 - **Testing**: Use `createTestApp()` for e2e, in-memory repositories for unit tests, mock factories in `@/test/mocks/`
 - **Format**: Prettier (semicolons, single quotes, 100 chars), ESLint with TypeScript strict rules
+
+## Contributing
+
+- **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`type: short description`)
+


### PR DESCRIPTION
## Summary
- document Prisma seed command and preloaded World Cup data
- note that teams, tournaments, and matches are read-only for regular users
- add commit message guidance

## Testing
- `npm run test:run`
- `npm run lint` *(fails: import/order and other existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd8a43e08328b924801de483f97a