### PR TITLE
feat: add public pools listing

### DIFF
--- a/src/http/controllers/pools/listPublicPoolsController.spec.ts
+++ b/src/http/controllers/pools/listPublicPoolsController.spec.ts
@@ -1,0 +1,41 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createServer } from '@/app';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createPool } from '@/test/mocks/pools';
+
+describe('List Public Pools Controller (e2e)', async () => {
+  const app = await createServer();
+  let token: string;
+  let poolsRepository: IPoolsRepository;
+
+  beforeAll(async () => {
+    await app.ready();
+    ({ token } = await getSupabaseAccessToken(app));
+    poolsRepository = new PrismaPoolsRepository();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should list public pools with pagination and name filter', async () => {
+    await createPool(poolsRepository, { name: 'Public Alpha', isPrivate: false });
+    await createPool(poolsRepository, { name: 'Public Beta', isPrivate: false });
+    await createPool(poolsRepository, { name: 'Secret Pool', isPrivate: true });
+
+    const response = await request(app.server)
+      .get('/pools')
+      .query({ page: 1, perPage: 1, name: 'Public' })
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pools');
+    expect(response.body.pools).toHaveLength(1);
+    expect(response.body.pools[0].name).toContain('Public');
+  });
+});

--- a/src/http/controllers/pools/listPublicPoolsController.spec.ts
+++ b/src/http/controllers/pools/listPublicPoolsController.spec.ts
@@ -1,21 +1,67 @@
+import { Pool } from '@prisma/client';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+
+type ListPublicPoolsResponse = {
+  pools: Pool[];
+};
 
 describe('List Public Pools Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
+  let userId: string;
   let token: string;
+
+  let usersRepository: IUsersRepository;
   let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
-    ({ token } = await getSupabaseAccessToken(app));
+    ({ token, userId } = await getSupabaseAccessToken(app));
+    usersRepository = new PrismaUsersRepository();
     poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+
+    const userA = await createUser(usersRepository, {
+      email: 'dunha@gmail.com',
+      fullName: 'Dunha',
+      profileImageUrl: 'http://avatar.com/dunha.png',
+    });
+
+    const tournament = await createTournament(tournamentsRepository, {});
+
+    await createPool(poolsRepository, {
+      name: 'Public Alpha',
+      description: 'First public pool',
+      creatorId: userA.id,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+    await createPool(poolsRepository, {
+      name: 'Public Beta',
+      description: 'Second public pool',
+      creatorId: userId,
+      tournamentId: tournament.id,
+      isPrivate: false,
+    });
+    await createPool(poolsRepository, {
+      name: 'Secret Pool',
+      description: 'A private pool',
+      creatorId: userA.id,
+      tournamentId: tournament.id,
+      isPrivate: true,
+    });
   });
 
   afterAll(async () => {
@@ -23,10 +69,6 @@ describe('List Public Pools Controller (e2e)', async () => {
   });
 
   it('should list public pools with pagination and name filter', async () => {
-    await createPool(poolsRepository, { name: 'Public Alpha', isPrivate: false });
-    await createPool(poolsRepository, { name: 'Public Beta', isPrivate: false });
-    await createPool(poolsRepository, { name: 'Secret Pool', isPrivate: true });
-
     const response = await request(app.server)
       .get('/pools')
       .query({ page: 1, perPage: 1, name: 'Public' })
@@ -35,7 +77,56 @@ describe('List Public Pools Controller (e2e)', async () => {
 
     expect(response.statusCode).toEqual(200);
     expect(response.body).toHaveProperty('pools');
-    expect(response.body.pools).toHaveLength(1);
-    expect(response.body.pools[0].name).toContain('Public');
+
+    const body = response.body as ListPublicPoolsResponse;
+    expect(body.pools).toHaveLength(1);
+    expect(body.pools[0].name).toContain('Public');
+  });
+
+  it('should return empty list if no public pools match the name filter', async () => {
+    const response = await request(app.server)
+      .get('/pools')
+      .query({ page: 1, perPage: 10, name: 'NonExistentPool' })
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pools');
+
+    const body = response.body as ListPublicPoolsResponse;
+    expect(body.pools).toHaveLength(0);
+  });
+
+  it('should list public pools without name filter', async () => {
+    const response = await request(app.server)
+      .get('/pools')
+      .query({ page: 1, perPage: 10 })
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pools');
+
+    const body = response.body as ListPublicPoolsResponse;
+    expect(body.pools.length).toBeGreaterThanOrEqual(2);
+    body.pools.forEach((pool) => {
+      expect(pool.isPrivate).toBe(false);
+    });
+  });
+
+  it('should not list private pools', async () => {
+    const response = await request(app.server)
+      .get('/pools')
+      .query({ page: 1, perPage: 10 })
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('pools');
+
+    const body = response.body as ListPublicPoolsResponse;
+    body.pools.forEach((pool) => {
+      expect(pool.isPrivate).toBe(false);
+    });
   });
 });

--- a/src/http/controllers/pools/listPublicPoolsController.ts
+++ b/src/http/controllers/pools/listPublicPoolsController.ts
@@ -1,0 +1,38 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { makeListPublicPoolsUseCase } from '@/useCases/pools/factory/makeListPublicPoolsUseCase';
+
+const listPublicPoolsQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  perPage: z.coerce.number().min(1).max(50).default(10),
+  name: z.string().optional(),
+});
+
+type ListPublicPoolsQuery = z.infer<typeof listPublicPoolsQuerySchema>;
+
+export async function listPublicPoolsController(
+  request: FastifyRequest<{ Querystring: ListPublicPoolsQuery }>,
+  reply: FastifyReply
+) {
+  try {
+    const { page, perPage, name } = listPublicPoolsQuerySchema.parse(request.query);
+
+    const listPublicPoolsUseCase = makeListPublicPoolsUseCase();
+    const { pools } = await listPublicPoolsUseCase.execute({
+      page,
+      perPage,
+      name,
+    });
+
+    return reply.status(200).send({ pools });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return reply
+        .status(422)
+        .send({ message: 'Validation error.', issues: error.format() });
+    }
+
+    throw error;
+  }
+}

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -8,6 +8,7 @@ import { getPoolUsersController } from '@/http/controllers/pools/getPoolUsersCon
 import { joinPoolByIdController } from '@/http/controllers/pools/joinPoolByIdController';
 import { joinPoolByInviteController } from '@/http/controllers/pools/joinPoolByInviteController';
 import { leavePoolController } from '@/http/controllers/pools/leavePoolController';
+import { listPublicPoolsController } from '@/http/controllers/pools/listPublicPoolsController';
 import { removeUserFromPoolController } from '@/http/controllers/pools/removeUserFromPoolController';
 import { updatePoolController } from '@/http/controllers/pools/updatePoolController';
 import { verifyJwt } from '@/http/middlewares/verifyJwt';
@@ -15,6 +16,33 @@ import { poolSchemas } from '@/http/schemas/pool.schemas';
 
 export function poolRoutes(app: FastifyInstance): void {
   app.addHook('onRequest', verifyJwt);
+
+  app.get(
+    '/pools',
+    {
+      schema: {
+        tags: ['Pools'],
+        summary: 'List public pools',
+        description: 'Lists public pools with optional pagination and name filtering',
+        querystring: poolSchemas.ListPublicPoolsQuery,
+        response: {
+          200: {
+            description: 'Public pools listed successfully',
+            ...poolSchemas.ListPublicPoolsResponse,
+          },
+          401: {
+            description: 'Unauthorized access',
+            ...poolSchemas.UnauthorizedError,
+          },
+          422: {
+            description: 'Validation error',
+            ...poolSchemas.PoolValidationError,
+          },
+        },
+      },
+    },
+    listPublicPoolsController
+  );
 
   app.post(
     '/pools',

--- a/src/http/schemas/pool.schemas.ts
+++ b/src/http/schemas/pool.schemas.ts
@@ -188,6 +188,39 @@ export const poolSchemas = {
     },
   },
 
+  // List Public Pools Query Parameters
+  ListPublicPoolsQuery: {
+    type: 'object',
+    properties: {
+      page: {
+        type: 'number',
+        minimum: 1,
+        description: 'Page number for pagination',
+      },
+      perPage: {
+        type: 'number',
+        minimum: 1,
+        maximum: 50,
+        description: 'Number of pools per page',
+      },
+      name: {
+        type: 'string',
+        description: 'Optional name filter',
+      },
+    },
+  },
+
+  // List Public Pools Response
+  ListPublicPoolsResponse: {
+    type: 'object',
+    properties: {
+      pools: {
+        type: 'array',
+        items: { $ref: 'Pool#' },
+      },
+    },
+  },
+
   // Leave Pool Response
   LeavePoolResponse: {
     type: 'object',

--- a/src/repositories/pools/IPoolsRepository.ts
+++ b/src/repositories/pools/IPoolsRepository.ts
@@ -16,6 +16,11 @@ export interface IPoolsRepository {
   findByInviteCode(inviteCode: string): Promise<Pool | null>;
   findByCreatorId(creatorId: string): Promise<Pool[]>;
   findByParticipantId(userId: string): Promise<Pool[]>;
+  findPublicPools(params: {
+    page: number;
+    perPage: number;
+    name?: string;
+  }): Promise<Pool[]>;
   getScoringRules(poolId: number): Promise<ScoringRule[]>;
   getPoolParticipants(poolId: number): Promise<PoolParticipant[]>;
   getPool(id: number): Promise<PoolCompleteInfo | null>;

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -312,6 +312,29 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
     );
   }
 
+  async findPublicPools({
+    page,
+    perPage,
+    name,
+  }: {
+    page: number;
+    perPage: number;
+    name?: string;
+  }): Promise<Pool[]> {
+    let pools = this.pools.filter((pool) => pool.isPrivate === false);
+
+    if (name) {
+      pools = pools.filter((pool) =>
+        pool.name.toLowerCase().includes(name.toLowerCase())
+      );
+    }
+
+    const startIndex = (page - 1) * perPage;
+    const endIndex = startIndex + perPage;
+
+    return pools.slice(startIndex, endIndex);
+  }
+
   async removeParticipant({ poolId, userId }: { poolId: number; userId: string }) {
     const participantIndex = this.participants.findIndex(
       (participant) => participant.poolId === poolId && participant.userId === userId

--- a/src/repositories/pools/PrismaPoolsRepository.ts
+++ b/src/repositories/pools/PrismaPoolsRepository.ts
@@ -137,6 +137,35 @@ export class PrismaPoolsRepository implements IPoolsRepository {
     return poolParticipants.map((participant) => participant.pool);
   }
 
+  async findPublicPools({
+    page,
+    perPage,
+    name,
+  }: {
+    page: number;
+    perPage: number;
+    name?: string;
+  }) {
+    const pools = await prisma.pool.findMany({
+      where: {
+        isPrivate: false,
+        ...(name
+          ? {
+              name: {
+                contains: name,
+                mode: 'insensitive',
+              },
+            }
+          : {}),
+      },
+      skip: (page - 1) * perPage,
+      take: perPage,
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return pools;
+  }
+
   async removeParticipant({ poolId, userId }: { poolId: number; userId: string }) {
     await prisma.poolParticipant.delete({
       where: {

--- a/src/useCases/pools/factory/makeListPublicPoolsUseCase.ts
+++ b/src/useCases/pools/factory/makeListPublicPoolsUseCase.ts
@@ -1,0 +1,8 @@
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+
+import { ListPublicPoolsUseCase } from '../listPublicPoolsUseCase';
+
+export function makeListPublicPoolsUseCase() {
+  const poolsRepository = new PrismaPoolsRepository();
+  return new ListPublicPoolsUseCase(poolsRepository);
+}

--- a/src/useCases/pools/listPublicPoolsUseCase.spec.ts
+++ b/src/useCases/pools/listPublicPoolsUseCase.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+
+import { ListPublicPoolsUseCase } from './listPublicPoolsUseCase';
+
+let poolsRepository: IPoolsRepository;
+let sut: ListPublicPoolsUseCase;
+
+describe('List Public Pools Use Case', () => {
+  beforeEach(() => {
+    poolsRepository = new InMemoryPoolsRepository();
+    sut = new ListPublicPoolsUseCase(poolsRepository);
+  });
+
+  it('should list public pools with pagination', async () => {
+    await poolsRepository.create({
+      name: 'Public Pool 1',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: 'user-1' } },
+      isPrivate: false,
+    });
+    await poolsRepository.create({
+      name: 'Public Pool 2',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: 'user-1' } },
+      isPrivate: false,
+    });
+    await poolsRepository.create({
+      name: 'Public Pool 3',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: 'user-1' } },
+      isPrivate: false,
+    });
+
+    const { pools: firstPage } = await sut.execute({ page: 1, perPage: 2 });
+    const { pools: secondPage } = await sut.execute({ page: 2, perPage: 2 });
+
+    expect(firstPage).toHaveLength(2);
+    expect(secondPage).toHaveLength(1);
+  });
+
+  it('should filter pools by name', async () => {
+    await poolsRepository.create({
+      name: 'Champions League',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: 'user-1' } },
+      isPrivate: false,
+    });
+    await poolsRepository.create({
+      name: 'World Cup',
+      tournament: { connect: { id: 1 } },
+      creator: { connect: { id: 'user-1' } },
+      isPrivate: false,
+    });
+
+    const { pools } = await sut.execute({ page: 1, perPage: 10, name: 'world' });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0].name).toBe('World Cup');
+  });
+});

--- a/src/useCases/pools/listPublicPoolsUseCase.ts
+++ b/src/useCases/pools/listPublicPoolsUseCase.ts
@@ -1,0 +1,21 @@
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+
+interface IListPublicPoolsRequest {
+  page: number;
+  perPage: number;
+  name?: string;
+}
+
+export class ListPublicPoolsUseCase {
+  constructor(private poolsRepository: IPoolsRepository) {}
+
+  async execute({ page, perPage, name }: IListPublicPoolsRequest) {
+    const pools = await this.poolsRepository.findPublicPools({
+      page,
+      perPage,
+      name,
+    });
+
+    return { pools };
+  }
+}


### PR DESCRIPTION
## Summary
- add use case to list public pools with pagination and name filter
- expose GET /pools route with controller and schemas
- cover listing with unit and e2e tests

## Testing
- `npm run lint` (fails: many style violations)
- `npm run test:run`
- `npm run test:e2e` (fails: invalid environment variables)


------
https://chatgpt.com/codex/tasks/task_e_68a82c8b33d48328b83a6001edbd9982