### PR TITLE
refactor: cache pool participants for join checks

### DIFF
--- a/src/useCases/pools/joinPoolByIdUseCase.spec.ts
+++ b/src/useCases/pools/joinPoolByIdUseCase.spec.ts
@@ -41,10 +41,12 @@ describe('Join Pool By ID Use Case', () => {
       tournament: { connect: { id: 1 } },
       creator: { connect: { id: creator.id } },
       isPrivate: false,
+      maxParticipants: 10,
     });
 
-    // Mock addParticipant
+    // Mock repository methods
     const addParticipantSpy = vi.spyOn(poolsRepository, 'addParticipant');
+    const getParticipantsSpy = vi.spyOn(poolsRepository, 'getPoolParticipants');
 
     // Join the pool
     const result = await sut.execute({
@@ -58,6 +60,7 @@ describe('Join Pool By ID Use Case', () => {
       poolId: pool.id,
       userId: joiner.id,
     });
+    expect(getParticipantsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should not be able to join a pool with non-existing user', async () => {

--- a/src/useCases/pools/joinPoolByIdUseCase.ts
+++ b/src/useCases/pools/joinPoolByIdUseCase.ts
@@ -39,12 +39,11 @@ export class JoinPoolByIdUseCase {
       );
     }
 
+    const participants = await this.poolsRepository.getPoolParticipants(pool.id);
+
     // Check if pool has a maximum number of participants
-    if (pool.maxParticipants) {
-      const participants = await this.poolsRepository.getPoolParticipants(pool.id);
-      if (participants.length >= pool.maxParticipants) {
-        throw new MaxParticipantsError(`${pool.maxParticipants}`);
-      }
+    if (pool.maxParticipants && participants.length >= pool.maxParticipants) {
+      throw new MaxParticipantsError(`${pool.maxParticipants}`);
     }
 
     // Check if registration deadline has passed
@@ -53,7 +52,6 @@ export class JoinPoolByIdUseCase {
     }
 
     // Check if user is already a participant
-    const participants = await this.poolsRepository.getPoolParticipants(pool.id);
     const isAlreadyParticipant = participants.some((participant) => participant.id === userId);
 
     if (isAlreadyParticipant) {

--- a/src/useCases/pools/joinPoolByInviteUseCase.spec.ts
+++ b/src/useCases/pools/joinPoolByInviteUseCase.spec.ts
@@ -42,10 +42,12 @@ describe('Join Pool By Invite Use Case', () => {
       creator: { connect: { id: creator.id } },
       isPrivate: true,
       inviteCode: 'SECRET-CODE',
+      maxParticipants: 10,
     });
 
-    // Mock addParticipant
+    // Mock repository methods
     const addParticipantSpy = vi.spyOn(poolsRepository, 'addParticipant');
+    const getParticipantsSpy = vi.spyOn(poolsRepository, 'getPoolParticipants');
 
     // Join the pool using invite code
     const result = await sut.execute({
@@ -59,6 +61,7 @@ describe('Join Pool By Invite Use Case', () => {
       poolId: pool.id,
       userId: joiner.id,
     });
+    expect(getParticipantsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should be able to join a public pool with invite code', async () => {

--- a/src/useCases/pools/joinPoolByInviteUseCase.ts
+++ b/src/useCases/pools/joinPoolByInviteUseCase.ts
@@ -37,12 +37,11 @@ export class JoinPoolByInviteUseCase {
       throw new UnauthorizedError('Invalid invite code');
     }
 
+    const participants = await this.poolsRepository.getPoolParticipants(pool.id);
+
     // Check if pool has a maximum number of participants
-    if (pool.maxParticipants) {
-      const participants = await this.poolsRepository.getPoolParticipants(pool.id);
-      if (participants.length >= pool.maxParticipants) {
-        throw new MaxParticipantsError(`${pool.maxParticipants}`);
-      }
+    if (pool.maxParticipants && participants.length >= pool.maxParticipants) {
+      throw new MaxParticipantsError(`${pool.maxParticipants}`);
     }
 
     // Check if registration deadline has passed
@@ -51,7 +50,6 @@ export class JoinPoolByInviteUseCase {
     }
 
     // Check if user is already a participant
-    const participants = await this.poolsRepository.getPoolParticipants(pool.id);
     const isAlreadyParticipant = participants.some((participant) => participant.id === userId);
 
     if (isAlreadyParticipant) {


### PR DESCRIPTION
## Summary
- reuse participant list for capacity and membership validation in join-by-id and join-by-invite use cases
- add unit tests ensuring participants are fetched only once during joins

## Testing
- `npx eslint src/useCases/pools/joinPoolByIdUseCase.ts src/useCases/pools/joinPoolByInviteUseCase.ts src/useCases/pools/joinPoolByIdUseCase.spec.ts src/useCases/pools/joinPoolByInviteUseCase.spec.ts`
- `npm run test:run -- src/useCases/pools/joinPoolByIdUseCase.spec.ts src/useCases/pools/joinPoolByInviteUseCase.spec.ts`
- ⚠️ `npm run lint` *(fails: import order errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68a83b954528832887938138d948b858