### PR TITLE
test: rename getLoggedUser test and drop node:test

### DIFF
--- a/src/http/controllers/user/getLoggedUserInfoController.spec.ts
+++ b/src/http/controllers/user/getLoggedUserInfoController.spec.ts
@@ -1,32 +1,38 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
 import { createServer } from '@/app';
 import { env } from '@/env/config';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
-import { it } from 'node:test';
-import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 describe('Get User Info (e2e)', async () => {
   const app = await createServer();
-  let userId: string;
   let token: string;
 
   beforeAll(async () => {
     await app.ready();
-    ({ token, userId } = await getSupabaseAccessToken(app));
+    ({ token } = await getSupabaseAccessToken(app));
   });
 
   afterAll(async () => {
     await app.close();
   });
 
-  test('should return user info', async () => {
+  it('should return user info', async () => {
     const response = await request(app.server)
       .get(`/users/me`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
     expect(response.statusCode).toEqual(200);
-    expect(response.body.user).toEqual(
+    const body = response.body as {
+      user: {
+        email: string;
+        fullName: string;
+        accountProvider: string;
+      };
+    };
+    expect(body.user).toEqual(
       expect.objectContaining({
         email: env.TEST_USER_EMAIL,
         fullName: 'John Tester',


### PR DESCRIPTION
## Summary
- rename getLoggedUserController spec to getLoggedUserInfoController spec
- remove usage of node:test and rely on vitest's it

## Testing
- `npm run test:e2e -- src/http/controllers/user/getLoggedUserInfoController.spec.ts` *(fails: invalid environment variables)*
- `npx eslint src/http/controllers/user/getLoggedUserInfoController.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac305f4adc832885b8aabf76158354