### PR TITLE
test: use shared app helper in controller specs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -154,15 +154,17 @@ export const closeGracefully = async (signal: string) => {
   process.exit(0);
 };
 
-process.on('SIGINT', () => {
-  closeGracefully('SIGINT').catch((err) => {
-    console.error('Error during graceful shutdown:', err);
-    process.exit(1);
+if (env.NODE_ENV !== 'test') {
+  process.on('SIGINT', () => {
+    closeGracefully('SIGINT').catch((err) => {
+      console.error('Error during graceful shutdown:', err);
+      process.exit(1);
+    });
   });
-});
-process.on('SIGTERM', () => {
-  closeGracefully('SIGTERM').catch((err) => {
-    console.error('Error during graceful shutdown:', err);
-    process.exit(1);
+  process.on('SIGTERM', () => {
+    closeGracefully('SIGTERM').catch((err) => {
+      console.error('Error during graceful shutdown:', err);
+      process.exit(1);
+    });
   });
-});
+}

--- a/src/http/controllers/matches/getMatchPredictionsController.spec.ts
+++ b/src/http/controllers/matches/getMatchPredictionsController.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { predictionSchemas } from '@/http/schemas/prediction.schemas';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
@@ -29,7 +29,7 @@ type GetMatchPredictionsResponse = {
 };
 
 describe('Get Match Predictions Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -41,7 +41,6 @@ describe('Get Match Predictions Controller (e2e)', async () => {
   let usersRepository: IUsersRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     matchesRepository = new PrismaMatchesRepository();
     teamsRepository = new PrismaTeamsRepository();
@@ -51,9 +50,6 @@ describe('Get Match Predictions Controller (e2e)', async () => {
     usersRepository = new PrismaUsersRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to get predictions for a match', async () => {
     // Create test data

--- a/src/http/controllers/pools/getPoolController.spec.ts
+++ b/src/http/controllers/pools/getPoolController.spec.ts
@@ -1,8 +1,8 @@
 import { Pool, ScoringRule, Tournament } from '@prisma/client';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
@@ -28,7 +28,7 @@ type ErrorResponse = {
 };
 
 describe('Get Pool Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -37,16 +37,12 @@ describe('Get Pool Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     usersRepository = new PrismaUsersRepository();
     poolsRepository = new PrismaPoolsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to get pool details as creator', async () => {
     const tournament = await createTournament(tournamentsRepository, {});

--- a/src/http/controllers/pools/getPoolPredictionsController.spec.ts
+++ b/src/http/controllers/pools/getPoolPredictionsController.spec.ts
@@ -1,8 +1,8 @@
 import { Match, Pool, Prediction } from '@prisma/client';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
@@ -34,7 +34,7 @@ type ErrorResponse = {
 };
 
 describe('Get Pool Predictions Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
   let tournamentId: number;
@@ -50,7 +50,6 @@ describe('Get Pool Predictions Controller (e2e)', async () => {
   let match: Match;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
 
     usersRepository = new PrismaUsersRepository();
@@ -94,9 +93,6 @@ describe('Get Pool Predictions Controller (e2e)', async () => {
     });
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should get pool predictions for pool creator', async () => {
     const response = await request(app.server)

--- a/src/http/controllers/pools/getPoolStandingsController.spec.ts
+++ b/src/http/controllers/pools/getPoolStandingsController.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { PoolStandings } from '@/global/types/poolStandings';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
@@ -25,7 +25,7 @@ type ErrorResponse = {
 };
 
 describe('Get Pool Standings Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -34,16 +34,12 @@ describe('Get Pool Standings Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     usersRepository = new PrismaUsersRepository();
     poolsRepository = new PrismaPoolsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to get standings from a pool as creator', async () => {
     const tournament = await createTournament(tournamentsRepository, {});

--- a/src/http/controllers/pools/getPoolUsersController.spec.ts
+++ b/src/http/controllers/pools/getPoolUsersController.spec.ts
@@ -1,8 +1,8 @@
 import { User } from '@prisma/client';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
@@ -26,7 +26,7 @@ type ErrorResponse = {
 };
 
 describe('Get Pool Users Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -35,16 +35,12 @@ describe('Get Pool Users Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     usersRepository = new PrismaUsersRepository();
     poolsRepository = new PrismaPoolsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should get pool users when user is pool creator', async () => {
     const tournament = await createTournament(tournamentsRepository, {});

--- a/src/http/controllers/pools/joinPoolByIdController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByIdController.spec.ts
@@ -1,8 +1,8 @@
 import { Pool } from '@prisma/client';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
@@ -25,7 +25,7 @@ type ErrorResponse = {
 };
 
 describe('Join Pool By ID Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
   let tournamentId: number;
@@ -35,7 +35,6 @@ describe('Join Pool By ID Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
 
     usersRepository = new PrismaUsersRepository();
@@ -46,9 +45,6 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     tournamentId = tournament.id;
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to join a public pool by ID', async () => {
     const poolCreator = await createUser(usersRepository, {

--- a/src/http/controllers/pools/joinPoolByInviteController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByInviteController.spec.ts
@@ -1,8 +1,8 @@
 import { Pool } from '@prisma/client';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
@@ -25,7 +25,7 @@ type ErrorResponse = {
 };
 
 describe('Join Pool By Invite Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
   let tournamentId: number;
@@ -35,7 +35,6 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
 
     usersRepository = new PrismaUsersRepository();
@@ -46,9 +45,6 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     tournamentId = tournament.id;
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to join a private pool with correct invite code', async () => {
     const poolCreator = await createUser(usersRepository, {

--- a/src/http/controllers/pools/leavePoolController.spec.ts
+++ b/src/http/controllers/pools/leavePoolController.spec.ts
@@ -1,4 +1,7 @@
-import { createServer } from '@/app';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
@@ -9,11 +12,9 @@ import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';
 import { createUser } from '@/test/mocks/users';
-import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 describe('Leave Pool Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -22,16 +23,12 @@ describe('Leave Pool Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     usersRepository = new PrismaUsersRepository();
     poolsRepository = new PrismaPoolsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to leave a pool', async () => {
     const tournament = await createTournament(tournamentsRepository, {});

--- a/src/http/controllers/pools/removeUserFromPoolController.spec.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
@@ -20,7 +20,7 @@ type ErrorResponse = {
 };
 
 describe('Remove User From Pool Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -29,16 +29,12 @@ describe('Remove User From Pool Controller (e2e)', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     usersRepository = new PrismaUsersRepository();
     poolsRepository = new PrismaPoolsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to remove a user from a pool', async () => {
     const tournament = await createTournament(tournamentsRepository, {});

--- a/src/http/controllers/tournaments/tournaments.e2e.spec.ts
+++ b/src/http/controllers/tournaments/tournaments.e2e.spec.ts
@@ -1,8 +1,8 @@
 import { Tournament, Match } from '@prisma/client';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
 import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
@@ -22,7 +22,7 @@ type TournamentMatchesResponse = {
 };
 
 describe('Tournaments E2E', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let token: string;
   let tournamentId: number;
 
@@ -31,7 +31,6 @@ describe('Tournaments E2E', async () => {
   let teamsRepository: ITeamsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token } = await getSupabaseAccessToken(app));
     tournamentsRepository = new PrismaTournamentsRepository();
     matchesRepository = new PrismaMatchesRepository();
@@ -47,9 +46,6 @@ describe('Tournaments E2E', async () => {
     }
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   describe('GET /tournaments', () => {
     it('should be able to list all tournaments', async () => {

--- a/src/http/controllers/user/getLoggedUserInfoController.spec.ts
+++ b/src/http/controllers/user/getLoggedUserInfoController.spec.ts
@@ -1,22 +1,18 @@
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { env } from '@/env/config';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 
 describe('Get User Info (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let token: string;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token } = await getSupabaseAccessToken(app));
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should return user info', async () => {
     const response = await request(app.server)

--- a/src/http/controllers/user/getUserInfoController.spec.ts
+++ b/src/http/controllers/user/getUserInfoController.spec.ts
@@ -1,22 +1,19 @@
-import { createServer } from '@/app';
+import request from 'supertest';
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { createTestApp } from '@/test/helper-e2e';
 import { prisma } from '@/lib/prisma';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
-import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 describe('Get User Info (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   test('should return user info', async () => {
     const user = await prisma.user.create({

--- a/src/http/controllers/user/getUserPoolsStandingsController.spec.ts
+++ b/src/http/controllers/user/getUserPoolsStandingsController.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createServer } from '@/app';
+import { createTestApp } from '@/test/helper-e2e';
 import { PoolStandings } from '@/global/types/poolStandings';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
@@ -24,7 +24,7 @@ type GetUserPoolsStandingsResponse = {
 };
 
 describe('Get User Pools Standings Controller (e2e)', async () => {
-  const app = await createServer();
+  const app = await createTestApp();
   let userId: string;
   let token: string;
 
@@ -35,7 +35,6 @@ describe('Get User Pools Standings Controller (e2e)', async () => {
   let predictionsRepository: IPredictionsRepository;
 
   beforeAll(async () => {
-    await app.ready();
     ({ token, userId } = await getSupabaseAccessToken(app));
     poolsRepository = new PrismaPoolsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
@@ -44,9 +43,6 @@ describe('Get User Pools Standings Controller (e2e)', async () => {
     predictionsRepository = new PrismaPredictionsRepository();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
 
   it('should be able to get user pools standings', async () => {
     const response = await request(app.server)


### PR DESCRIPTION
## Summary
- use `createTestApp` helper across controller e2e specs
- remove redundant `app.ready()` and `app.close()` calls

## Testing
- `npm run test:e2e -- src/http/controllers/pools/getPoolController.spec.ts` *(fails: DATABASE_URL env missing for Prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68ac34255db883289226301c2e3bbec6