### PR TITLE
feat: update pool membership endpoints

### DIFF
--- a/src/http/controllers/pools/joinPoolByIdController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByIdController.spec.ts
@@ -59,7 +59,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -94,7 +94,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -115,7 +115,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     const nonExistentPoolId = 9999;
 
     const response = await request(app.server)
-      .post(`/pools/${nonExistentPoolId}/join`)
+      .post(`/pools/${nonExistentPoolId}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -142,7 +142,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
   //   const fakeToken = await getSupabaseAccessToken(app, 'non-existent-user-id');
 
   //   const response = await request(app.server)
-  //     .post(`/pools/${pool.id}/join`)
+  //     .post(`/pools/${pool.id}/users`)
   //     .set('Authorization', `Bearer ${fakeToken.token}`)
   //     .send();
 
@@ -167,13 +167,13 @@ describe('Join Pool By ID Controller (e2e)', async () => {
 
     // First join
     await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
     // Second join attempt
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -216,7 +216,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -244,7 +244,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -267,14 +267,14 @@ describe('Join Pool By ID Controller (e2e)', async () => {
       isPrivate: false,
     });
 
-    const response = await request(app.server).post(`/pools/${pool.id}/join`).send();
+    const response = await request(app.server).post(`/pools/${pool.id}/users`).send();
 
     expect(response.statusCode).toEqual(401);
   });
 
   it('should validate pool ID parameter', async () => {
     const response = await request(app.server)
-      .post('/pools/invalid-id/join')
+      .post('/pools/invalid-id/users')
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -287,7 +287,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
 
   it('should handle negative pool ID', async () => {
     const response = await request(app.server)
-      .post('/pools/-1/join')
+      .post('/pools/-1/users')
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -311,7 +311,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -343,7 +343,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -366,7 +366,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
 
   it('should handle zero as pool ID', async () => {
     const response = await request(app.server)
-      .post('/pools/0/join')
+      .post('/pools/0/users')
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -381,7 +381,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     const veryLargeId = 999999999;
 
     const response = await request(app.server)
-      .post(`/pools/${veryLargeId}/join`)
+      .post(`/pools/${veryLargeId}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -406,7 +406,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/join`)
+      .post(`/pools/${pool.id}/users`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -442,7 +442,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
   //   });
 
   //   const response = await request(app.server)
-  //     .post(`/pools/${pool.id}/join`)
+  //     .post(`/pools/${pool.id}/users`)
   //     .set('Authorization', `Bearer ${token}`)
   //     .send();
 

--- a/src/http/controllers/pools/joinPoolByInviteController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByInviteController.spec.ts
@@ -60,7 +60,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -95,7 +95,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -118,7 +118,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
 
   it('should return 404 when invite code does not exist', async () => {
     const response = await request(app.server)
-      .post('/pools/join/NON-EXISTENT-CODE')
+      .post('/pool-invites/NON-EXISTENT-CODE')
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -143,13 +143,13 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
 
     // First join
     await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
     // Second join attempt
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -183,7 +183,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -211,7 +211,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -234,14 +234,14 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
       inviteCode: 'AUTH-CODE',
     });
 
-    const response = await request(app.server).post(`/pools/join/${pool.inviteCode}`).send();
+    const response = await request(app.server).post(`/pool-invites/${pool.inviteCode}`).send();
 
     expect(response.statusCode).toEqual(401);
   });
 
   it('should validate invite code parameter', async () => {
     const response = await request(app.server)
-      .post('/pools/join/')
+      .post('/pool-invites/')
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -250,7 +250,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
 
   it('should handle empty invite code', async () => {
     const response = await request(app.server)
-      .post('/pools/join/ ')
+      .post('/pool-invites/ ')
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -274,7 +274,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
@@ -306,7 +306,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/join/${pool.inviteCode}`)
+      .post(`/pool-invites/${pool.inviteCode}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 

--- a/src/http/controllers/pools/leavePoolController.spec.ts
+++ b/src/http/controllers/pools/leavePoolController.spec.ts
@@ -49,7 +49,7 @@ describe('Leave Pool Controller (e2e)', async () => {
 
     // Then leave the pool
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/leave`)
+      .delete(`/pools/${pool.id}/users/me`)
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(200);
@@ -59,7 +59,7 @@ describe('Leave Pool Controller (e2e)', async () => {
     const nonExistentPoolId = 9999;
 
     const response = await request(app.server)
-      .post(`/pools/${nonExistentPoolId}/leave`)
+      .delete(`/pools/${nonExistentPoolId}/users/me`)
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(404);
@@ -79,7 +79,7 @@ describe('Leave Pool Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/leave`)
+      .delete(`/pools/${pool.id}/users/me`)
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(403);
@@ -98,7 +98,7 @@ describe('Leave Pool Controller (e2e)', async () => {
     });
 
     const response = await request(app.server)
-      .post(`/pools/${pool.id}/leave`)
+      .delete(`/pools/${pool.id}/users/me`)
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(403);
@@ -119,7 +119,7 @@ describe('Leave Pool Controller (e2e)', async () => {
       tournamentId: tournament.id,
     });
 
-    const response = await request(app.server).post(`/pools/${pool.id}/leave`);
+    const response = await request(app.server).delete(`/pools/${pool.id}/users/me`);
 
     expect(response.statusCode).toEqual(401);
   });

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -114,7 +114,7 @@ export function poolRoutes(app: FastifyInstance): void {
 
   // Join pool by ID (public pools)
   app.post(
-    '/pools/:poolId/join',
+    '/pools/:poolId/users',
     {
       schema: {
         tags: ['Pools'],
@@ -156,7 +156,7 @@ export function poolRoutes(app: FastifyInstance): void {
 
   // Join pool by invite code (works for both public and private pools)
   app.post(
-    '/pools/join/:inviteCode',
+    '/pool-invites/:inviteCode',
     {
       schema: {
         tags: ['Pools'],
@@ -196,13 +196,13 @@ export function poolRoutes(app: FastifyInstance): void {
     joinPoolByInviteController
   );
 
-  app.post(
-    '/pools/:poolId/leave',
+  app.delete(
+    '/pools/:poolId/users/me',
     {
       schema: {
         tags: ['Pools'],
         summary: 'Leave a pool',
-        description: 'Leave a pool that the authenticated user has joined',
+        description: 'Remove the authenticated user from the specified pool',
         params: poolSchemas.PoolIdParam,
         response: {
           200: {


### PR DESCRIPTION
## Summary
- replace pool join-by-id route with `POST /pools/:poolId/users`
- change invite join route to `POST /pool-invites/:inviteCode`
- use `DELETE /pools/:poolId/users/me` for leaving pools

## Testing
- `npm run lint` *(fails: There should be at least one empty line between import groups)*
- `npm run test:run`
- `npm run test:e2e` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b011e848d883288e76ad7ccf900c8f