### PR TITLE
feat: confirm user removal from pool

### DIFF
--- a/src/http/controllers/pools/removeUserFromPoolController.spec.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.spec.ts
@@ -59,6 +59,9 @@ describe('Remove User From Pool Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual({
+      message: 'User successfully removed from pool',
+    });
 
     const participants = await poolsRepository.getPoolParticipants(pool.id);
     const isUserStillParticipant = participants.some(

--- a/src/http/controllers/pools/removeUserFromPoolController.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.ts
@@ -26,7 +26,9 @@ export async function removeUserFromPoolController(
       creatorId,
     });
 
-    return reply.status(200).send();
+    return reply
+      .status(200)
+      .send({ message: 'User successfully removed from pool' });
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
       return reply.status(404).send({ message: error.message });


### PR DESCRIPTION
## Summary
- add success message to removeUserFromPoolController
- verify success message in removeUserFromPoolController e2e test

## Testing
- `npm run lint` *(fails: import/order issues, missing return types)*
- `npm run test:e2e -- src/http/controllers/pools/removeUserFromPoolController.spec.ts` *(fails: invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b015bce20c832896a28f32668bcdd8