### PR TITLE
fix: return 403 on unauthorized pool joins

### DIFF
--- a/src/http/controllers/pools/joinPoolByIdController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByIdController.spec.ts
@@ -80,7 +80,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
     expect(participants.some((p) => p.id === userId)).toBe(true);
   });
 
-  it('should return 401 when trying to join a private pool by ID', async () => {
+  it('should return 403 when trying to join a private pool by ID', async () => {
     const poolCreator = await createUser(usersRepository, {
       email: 'private-creator@example.com',
     });
@@ -98,7 +98,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`)
       .send();
 
-    expect(response.statusCode).toEqual(401);
+    expect(response.statusCode).toEqual(403);
 
     const body = response.body as ErrorResponse;
     expect(body).toHaveProperty('message');
@@ -153,7 +153,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
   //   expect(body.message).toContain('User not found');
   // });
 
-  it('should return 401 when user is already a participant', async () => {
+  it('should return 403 when user is already a participant', async () => {
     const poolCreator = await createUser(usersRepository, {
       email: 'creator-duplicate@example.com',
     });
@@ -177,7 +177,7 @@ describe('Join Pool By ID Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`)
       .send();
 
-    expect(response.statusCode).toEqual(401);
+    expect(response.statusCode).toEqual(403);
 
     const body = response.body as ErrorResponse;
     expect(body).toHaveProperty('message');

--- a/src/http/controllers/pools/joinPoolByIdController.ts
+++ b/src/http/controllers/pools/joinPoolByIdController.ts
@@ -33,7 +33,7 @@ export async function joinPoolByIdController(
     }
 
     if (error instanceof UnauthorizedError) {
-      return reply.status(401).send({ message: error.message });
+      return reply.status(403).send({ message: error.message });
     }
 
     if (error instanceof MaxParticipantsError) {

--- a/src/http/controllers/pools/joinPoolByInviteController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByInviteController.spec.ts
@@ -129,7 +129,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
     expect(body.message).toContain('Pool not found with this invite code');
   });
 
-  it('should return 401 when user is already a participant', async () => {
+  it('should return 403 when user is already a participant', async () => {
     const poolCreator = await createUser(usersRepository, {
       email: 'creator-duplicate@example.com',
     });
@@ -153,7 +153,7 @@ describe('Join Pool By Invite Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`)
       .send();
 
-    expect(response.statusCode).toEqual(401);
+    expect(response.statusCode).toEqual(403);
 
     const body = response.body as ErrorResponse;
     expect(body).toHaveProperty('message');

--- a/src/http/controllers/pools/joinPoolByInviteController.ts
+++ b/src/http/controllers/pools/joinPoolByInviteController.ts
@@ -33,7 +33,7 @@ export async function joinPoolByInviteController(
     }
 
     if (error instanceof UnauthorizedError) {
-      return reply.status(401).send({ message: error.message });
+      return reply.status(403).send({ message: error.message });
     }
 
     if (error instanceof MaxParticipantsError) {

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -129,8 +129,8 @@ export function poolRoutes(app: FastifyInstance): void {
               pool: poolSchemas.Pool,
             },
           },
-          401: {
-            description: 'Unauthorized to join this pool',
+          403: {
+            description: 'Forbidden to join this pool',
             ...poolSchemas.UnauthorizedError,
           },
           404: {
@@ -171,8 +171,8 @@ export function poolRoutes(app: FastifyInstance): void {
               pool: poolSchemas.Pool,
             },
           },
-          401: {
-            description: 'Unauthorized to join this pool',
+          403: {
+            description: 'Forbidden to join this pool',
             ...poolSchemas.UnauthorizedError,
           },
           404: {


### PR DESCRIPTION
## Summary
- use 403 Forbidden for unauthorized join pool requests
- document 403 in pool join routes
- update tests for new status codes

## Testing
- `npm test`
- `npm run test:e2e` *(fails: invalid environment variables)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b01978a9448328a20c6d8b7c0e6583