### PR TITLE
refactor: rely on zod for pool creation validation

### DIFF
--- a/src/http/controllers/pools/createPoolController.spec.ts
+++ b/src/http/controllers/pools/createPoolController.spec.ts
@@ -172,10 +172,10 @@ describe('Create Pool Controller (e2e)', async () => {
         // Missing name and tournamentId
       });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(422);
 
     const body = response.body as ErrorResponse;
-    expect(body).toHaveProperty('code', 'FST_ERR_VALIDATION');
-    expect(body).toHaveProperty('error', 'Bad Request');
+    expect(body).toHaveProperty('message', 'Validation error');
+    expect(body).toHaveProperty('issues');
   });
 });

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -51,7 +51,6 @@ export function poolRoutes(app: FastifyInstance): void {
         tags: ['Pools'],
         summary: 'Create a new pool',
         description: 'Creates a new prediction pool with a unique invitation code',
-        body: poolSchemas.CreatePoolRequest,
         response: {
           201: {
             description: 'Pool created successfully',


### PR DESCRIPTION
## Summary
- remove Fastify body schema from pool creation route and rely on Zod in controller
- adjust create pool tests to expect Zod validation responses

## Testing
- `npm run lint` *(fails: 294 problems (226 errors, 68 warnings))*
- `npm run test:run`
- `THE_APP_NAME=test THE_APP_SECRET=secret THE_APP_VERSION=1.0 SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=anon TEST_USER_EMAIL=test@example.com TEST_USER_PASSWORD=pass npm run test:e2e` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b55d802e9483289ad7e0af89ce0318