### PR TITLE
fix: remove swagger UI static CSP config

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -108,8 +108,6 @@ export const createServer = async (): Promise<FastifyInstance> => {
           next();
         },
       },
-      staticCSP: true,
-      transformStaticCSP: (header) => header,
       transformSpecification: (swaggerObject, _request, _reply) => {
         return swaggerObject;
       },


### PR DESCRIPTION
## Summary
- remove `staticCSP` and `transformStaticCSP` from swagger UI setup

## Testing
- `curl -I http://localhost:3000/docs`
- `curl -I http://localhost:3000/docs/static/swagger-ui.css`
- `curl -I http://localhost:3000/docs/static/swagger-ui-bundle.js`
- `npm run lint` *(fails: 218 errors)*
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b801124d188328958685e5bdf16e21