### PR TITLE
refactor: centralize common HTTP error schemas

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ export const createServer = async (): Promise<FastifyInstance> => {
   });
 
   // Import schemas first
+  const { commonSchemas } = await import('./http/schemas/common.schemas');
   const { poolSchemas } = await import('./http/schemas/pool.schemas');
   const { userSchemas } = await import('./http/schemas/user.schemas');
   const { matchSchemas } = await import('./http/schemas/match.schemas');
@@ -54,6 +55,7 @@ export const createServer = async (): Promise<FastifyInstance> => {
     });
   };
 
+  mergeSchemas(commonSchemas);
   mergeSchemas(poolSchemas);
   mergeSchemas(userSchemas);
   mergeSchemas(matchSchemas);

--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -4,6 +4,7 @@ import { getMatchController } from '@/http/controllers/matches/getMatchControlle
 import { getMatchPredictionsController } from '@/http/controllers/matches/getMatchPredictionsController';
 import { updateMatchController } from '@/http/controllers/matches/updateMatchController';
 import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { commonSchemas } from '@/http/schemas/common.schemas';
 import { matchSchemas } from '@/http/schemas/match.schemas';
 
 export function matchesRoutes(app: FastifyInstance): void {
@@ -25,11 +26,11 @@ export function matchesRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...matchSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'Match not found',
-            ...matchSchemas.MatchNotFoundError,
+            ...commonSchemas.MatchNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -61,11 +62,11 @@ export function matchesRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...matchSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'Match not found',
-            ...matchSchemas.MatchNotFoundError,
+            ...commonSchemas.MatchNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -98,7 +99,7 @@ export function matchesRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...matchSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'Insufficient permissions to update match',
@@ -106,7 +107,7 @@ export function matchesRoutes(app: FastifyInstance): void {
           },
           404: {
             description: 'Match not found',
-            ...matchSchemas.MatchNotFoundError,
+            ...commonSchemas.MatchNotFoundError,
           },
           422: {
             description: 'Validation error',

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -12,6 +12,7 @@ import { listPublicPoolsController } from '@/http/controllers/pools/listPublicPo
 import { removeUserFromPoolController } from '@/http/controllers/pools/removeUserFromPoolController';
 import { updatePoolController } from '@/http/controllers/pools/updatePoolController';
 import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { commonSchemas } from '@/http/schemas/common.schemas';
 import { poolSchemas } from '@/http/schemas/pool.schemas';
 
 export function poolRoutes(app: FastifyInstance): void {
@@ -32,7 +33,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           422: {
             description: 'Validation error',
@@ -62,7 +63,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           422: {
             description: 'Validation error',
@@ -96,11 +97,11 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'Pool not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -131,7 +132,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           403: {
             description: 'Forbidden to join this pool',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'Pool or user not found',
@@ -173,7 +174,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           403: {
             description: 'Forbidden to join this pool',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'Pool not found with this invite code',
@@ -215,15 +216,15 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'User is not a member of this pool',
-            ...poolSchemas.NotPoolMemberError,
+            ...commonSchemas.NotPoolMemberError,
           },
           404: {
             description: 'Pool not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -255,7 +256,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'Only pool owner can remove users',
@@ -263,7 +264,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           404: {
             description: 'Pool or user not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -301,15 +302,15 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'User is not a member of this pool',
-            ...poolSchemas.NotPoolMemberError,
+            ...commonSchemas.NotPoolMemberError,
           },
           404: {
             description: 'Pool not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -340,7 +341,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'Only pool owner can update the pool',
@@ -348,7 +349,7 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           404: {
             description: 'Pool not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -385,15 +386,15 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'User is not a member of this pool',
-            ...poolSchemas.NotPoolMemberError,
+            ...commonSchemas.NotPoolMemberError,
           },
           404: {
             description: 'Pool not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',
@@ -438,15 +439,15 @@ export function poolRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...poolSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'User is not a member of this pool',
-            ...poolSchemas.NotPoolMemberError,
+            ...commonSchemas.NotPoolMemberError,
           },
           404: {
             description: 'Pool not found',
-            ...poolSchemas.PoolNotFoundError,
+            ...commonSchemas.PoolNotFoundError,
           },
           422: {
             description: 'Validation error',

--- a/src/http/routes/predictions.routes.ts
+++ b/src/http/routes/predictions.routes.ts
@@ -4,6 +4,7 @@ import { createPredictionController } from '@/http/controllers/predictions/creat
 import { getPredictionController } from '@/http/controllers/predictions/getPredictionController';
 import { updatePredictionController } from '@/http/controllers/predictions/updatePredictionController';
 import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { commonSchemas } from '@/http/schemas/common.schemas';
 import { predictionSchemas } from '@/http/schemas/prediction.schemas';
 
 export async function predictionsRoutes(app: FastifyInstance) {
@@ -25,7 +26,7 @@ export async function predictionsRoutes(app: FastifyInstance) {
         },
         401: {
           description: 'Unauthorized to create prediction',
-          ...predictionSchemas.UnauthorizedError,
+          ...commonSchemas.UnauthorizedError,
         },
         400: {
           description: 'Match has already started or prediction already exists',
@@ -36,13 +37,13 @@ export async function predictionsRoutes(app: FastifyInstance) {
         },
         403: {
           description: 'User is not a member of this pool',
-          ...predictionSchemas.NotPoolMemberError,
+          ...commonSchemas.NotPoolMemberError,
         },
         404: {
           description: 'Pool or match not found',
           oneOf: [
-            predictionSchemas.PoolNotFoundError,
-            predictionSchemas.MatchNotFoundError,
+            commonSchemas.PoolNotFoundError,
+            commonSchemas.MatchNotFoundError,
           ],
         },
         422: {
@@ -116,7 +117,7 @@ export async function predictionsRoutes(app: FastifyInstance) {
         },
         401: {
           description: 'Unauthorized to access this prediction',
-          ...predictionSchemas.UnauthorizedError
+          ...commonSchemas.UnauthorizedError
         },
         404: {
           description: 'Prediction not found',
@@ -155,7 +156,7 @@ export async function predictionsRoutes(app: FastifyInstance) {
         },
         401: {
           description: 'Unauthorized to update this prediction',
-          ...predictionSchemas.UnauthorizedError
+          ...commonSchemas.UnauthorizedError
         },
         404: {
           description: 'Prediction not found',

--- a/src/http/routes/tournaments.routes.ts
+++ b/src/http/routes/tournaments.routes.ts
@@ -4,6 +4,7 @@ import { getTournamentMatchesController } from '@/http/controllers/tournaments/g
 import { listTournamentsController } from '@/http/controllers/tournaments/listTournamentsController';
 import { verifyJwt } from '@/http/middlewares/verifyJwt';
 import { matchSchemas } from '@/http/schemas/match.schemas';
+import { commonSchemas } from '@/http/schemas/common.schemas';
 import { tournamentSchemas } from '@/http/schemas/tournament.schemas';
 
 export function tournamentsRoutes(app: FastifyInstance): void {
@@ -28,7 +29,7 @@ export function tournamentsRoutes(app: FastifyInstance): void {
               total: { type: 'number' },
             },
           },
-          401: tournamentSchemas.UnauthorizedError,
+          401: commonSchemas.UnauthorizedError,
           500: tournamentSchemas.TournamentInternalServerError,
         },
       },
@@ -58,7 +59,7 @@ export function tournamentsRoutes(app: FastifyInstance): void {
             },
             required: ['matches'],
           },
-          401: tournamentSchemas.UnauthorizedError,
+          401: commonSchemas.UnauthorizedError,
           404: tournamentSchemas.TournamentNotFoundError,
           422: tournamentSchemas.TournamentValidationError,
           500: tournamentSchemas.TournamentInternalServerError,

--- a/src/http/routes/user.routes.ts
+++ b/src/http/routes/user.routes.ts
@@ -8,6 +8,7 @@ import { getUserPoolsStandingsController } from '@/http/controllers/user/getUser
 import { getUserPredictionsController } from '@/http/controllers/user/getUserPredictionsController';
 import { updateUserController } from '@/http/controllers/user/updateUserController';
 import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { commonSchemas } from '@/http/schemas/common.schemas';
 import { userSchemas } from '@/http/schemas/user.schemas';
 
 export function userRoutes(app: FastifyInstance): void {
@@ -63,7 +64,7 @@ export function userRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...userSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'User not found',
@@ -123,7 +124,7 @@ export function userRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...userSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'User not found',
@@ -187,7 +188,7 @@ export function userRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...userSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           403: {
             description: 'User is not a participant of the specified pool',
@@ -232,7 +233,7 @@ export function userRoutes(app: FastifyInstance): void {
           },
           401: {
             description: 'Unauthorized access',
-            ...userSchemas.UnauthorizedError,
+            ...commonSchemas.UnauthorizedError,
           },
           404: {
             description: 'User not found',

--- a/src/http/schemas/common.schemas.ts
+++ b/src/http/schemas/common.schemas.ts
@@ -1,0 +1,29 @@
+export const commonSchemas = {
+  UnauthorizedError: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'Unauthorized' },
+    },
+  },
+
+  MatchNotFoundError: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'Match not found' },
+    },
+  },
+
+  PoolNotFoundError: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'Pool not found' },
+    },
+  },
+
+  NotPoolMemberError: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'User is not a member of this pool' },
+    },
+  },
+};

--- a/src/http/schemas/match.schemas.ts
+++ b/src/http/schemas/match.schemas.ts
@@ -168,14 +168,6 @@ export const matchSchemas = {
     additionalProperties: false,
   },
 
-  // Error schemas - Remove duplicates, keep only unique ones
-  MatchNotFoundError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Match not found' },
-    },
-  },
-
   ForbiddenError: {
     type: 'object',
     properties: {
@@ -191,13 +183,6 @@ export const matchSchemas = {
         type: 'object',
         additionalProperties: true,
       },
-    },
-  },
-
-  UnauthorizedError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Unauthorized' },
     },
   },
 

--- a/src/http/schemas/pool.schemas.ts
+++ b/src/http/schemas/pool.schemas.ts
@@ -427,13 +427,6 @@ export const poolSchemas = {
   },
 
   // Error responses specific to pools
-  PoolNotFoundError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Pool not found' },
-    },
-  },
-
   InvalidPoolCodeError: {
     type: 'object',
     properties: {
@@ -448,13 +441,6 @@ export const poolSchemas = {
     },
   },
 
-  NotPoolMemberError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'User is not a member of this pool' },
-    },
-  },
-
   NotPoolOwnerError: {
     type: 'object',
     properties: {
@@ -466,13 +452,6 @@ export const poolSchemas = {
     type: 'object',
     properties: {
       message: { type: 'string', example: 'Pool owner cannot leave their own pool' },
-    },
-  },
-
-  UnauthorizedError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Unauthorized access' },
     },
   },
 

--- a/src/http/schemas/prediction.schemas.ts
+++ b/src/http/schemas/prediction.schemas.ts
@@ -85,27 +85,6 @@ export const predictionSchemas = {
     }
   },
 
-  MatchNotFoundError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Match not found' }
-    }
-  },
-
-  PoolNotFoundError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Pool not found' }
-    }
-  },
-
-  NotPoolMemberError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'User is not a member of this pool' }
-    }
-  },
-
   PredictionAlreadyExistsError: {
     type: 'object',
     properties: {
@@ -119,14 +98,6 @@ export const predictionSchemas = {
       message: { type: 'string', example: 'Cannot create/update prediction for a match that has already started' }
     }
   },
-
-  UnauthorizedError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Unauthorized to access this prediction' }
-    }
-  },
-
   PredictionInternalServerError: {
     type: 'object',
     properties: {

--- a/src/http/schemas/tournament.schemas.ts
+++ b/src/http/schemas/tournament.schemas.ts
@@ -179,13 +179,6 @@ export const tournamentSchemas = {
     },
   },
 
-  UnauthorizedError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Unauthorized' },
-    },
-  },
-
   TournamentInternalServerError: {
     type: 'object',
     properties: {

--- a/src/http/schemas/user.schemas.ts
+++ b/src/http/schemas/user.schemas.ts
@@ -265,13 +265,6 @@ export const userSchemas = {
     },
   },
 
-  UnauthorizedError: {
-    type: 'object',
-    properties: {
-      message: { type: 'string', example: 'Unauthorized access' },
-    },
-  },
-
   UserInternalServerError: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary
- add shared HTTP error schemas module
- wire common schemas into app
- refactor routes to reference common error schemas

## Testing
- `npm run lint` (fails: 219 errors)
- `npm run test:run`
- `npm run test:e2e` (fails: invalid environment variables)


------
https://chatgpt.com/codex/tasks/task_e_68b802af04cc8328ba42d71255f771ed