### PR TITLE
docs: add env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Application
+NODE_ENV=dev
+THE_APP_NAME=
+THE_APP_SECRET=
+THE_APP_VERSION=
+PORT=3333
+HOST=0.0.0.0
+LOG_LEVEL=info
+
+# Supabase
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Database
+DATABASE_URL=postgresql://docker:docker@localhost:5432/bolao
+
+# Test helpers
+TEST_USER_EMAIL=
+TEST_USER_PASSWORD=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Big Bolão API - Agent Guide
 
+## Setup
+
+- Copy `.env.example` to `.env` and fill in all required values.
+
 ## Commands
 
 - **Dev**: `npm run dev` (watch mode with tsx)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Big Bolão API
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Provide values for Supabase keys, database credentials, and other variables before running the app.
+
+## Development
+
+See `AGENTS.md` for commands and project guidelines.


### PR DESCRIPTION
## Summary
- provide `.env.example` with Supabase and database variables
- document copying env example in AGENTS and README

## Testing
- `npm run lint` *(fails: 288 problems)*
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b94f03d22c83288d440703d505f1aa