### PR TITLE
build: add Dockerfile for container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:20-alpine
 WORKDIR /app
+
 COPY package*.json ./
-RUN npm install --production
+RUN npm ci             # install dev + prod deps
+
 COPY . .
-RUN npm run build
-CMD ["node", "build/server.js"]
+RUN npm run build      # generates build/server.js
+RUN npx prisma generate  # generates prisma client
+RUN npm prune --production  # optional: keep only prod deps
+
+CMD ["node", "build/server.cjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+RUN npm run build
+CMD ["node", "build/server.js"]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
-    "pino-pretty": "^13.0.0",
     "prettier": "^3.6.2",
     "supertest": "^7.0.0",
     "tsup": "^8.4.0",
@@ -61,6 +60,7 @@
     "dotenv": "^16.4.7",
     "fastify": "^5.2.1",
     "npm-run-all": "^4.1.5",
+    "pino-pretty": "^13.0.0",
     "prisma": "^6.4.1",
     "zod": "^3.24.2"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,8 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- add Dockerfile to build and run the API in a Node 20 container

## Testing
- `npm run lint` *(fails: import order issues in existing tests)*
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b950e579588328ab935b1ebc5df9f4