### PR TITLE
feat: add supabase token middleware

### DIFF
--- a/src/http/controllers/tournaments/listTournamentsController.e2e.spec.ts
+++ b/src/http/controllers/tournaments/listTournamentsController.e2e.spec.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { createTestApp } from '@/test/helper-e2e';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createTournament } from '@/test/mocks/tournament';
 
 type TournamentResponse = {
@@ -18,7 +19,7 @@ describe('GET /tournaments', async () => {
   let tournamentsRepository: ITournamentsRepository;
 
   beforeAll(async () => {
-    token = app.jwt.sign({ sub: 'test-user' });
+    ({ token } = await getSupabaseAccessToken(app));
     tournamentsRepository = new PrismaTournamentsRepository();
 
     await createTournament(tournamentsRepository, {});

--- a/src/http/middlewares/verifySupabaseToken.spec.ts
+++ b/src/http/middlewares/verifySupabaseToken.spec.ts
@@ -1,0 +1,63 @@
+import fastify, { FastifyInstance } from 'fastify';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getUserMock } = vi.hoisted(() => ({
+  getUserMock: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: getUserMock,
+    },
+  },
+}));
+
+import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
+
+describe('verifySupabaseToken middleware', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    getUserMock.mockReset();
+    app = fastify();
+    app.addHook('onRequest', verifySupabaseToken);
+    app.get('/protected', (req) => ({ userId: req.user.sub }));
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should allow requests with valid token', async () => {
+    getUserMock.mockResolvedValueOnce({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    });
+
+    const response = await request(app.server)
+      .get('/protected')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ userId: 'user-123' });
+  });
+
+  it('should reject requests without authorization header', async () => {
+    const response = await request(app.server).get('/protected');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should reject requests with invalid token', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: null }, error: new Error('Invalid') });
+
+    const response = await request(app.server)
+      .get('/protected')
+      .set('Authorization', 'Bearer invalid-token');
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/http/middlewares/verifySupabaseToken.ts
+++ b/src/http/middlewares/verifySupabaseToken.ts
@@ -1,0 +1,28 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+import { supabase } from '@/lib/supabase';
+
+export async function verifySupabaseToken(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  try {
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) {
+      throw new Error('Missing authorization header');
+    }
+
+    const token = authHeader.replace(/^Bearer\s+/i, '');
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      throw error || new Error('Invalid token');
+    }
+
+    request.user = { sub: data.user.id };
+  } catch {
+    return reply.status(401).send({ message: 'Unauthorized.' });
+  }
+}

--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -3,12 +3,12 @@ import { FastifyInstance } from 'fastify';
 import { getMatchController } from '@/http/controllers/matches/getMatchController';
 import { getMatchPredictionsController } from '@/http/controllers/matches/getMatchPredictionsController';
 import { updateMatchController } from '@/http/controllers/matches/updateMatchController';
-import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { matchSchemas } from '@/http/schemas/match.schemas';
 
 export function matchesRoutes(app: FastifyInstance): void {
-  app.addHook('onRequest', verifyJwt);
+  app.addHook('onRequest', verifySupabaseToken);
 
   app.get(
     '/matches/:matchId',

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -11,12 +11,12 @@ import { leavePoolController } from '@/http/controllers/pools/leavePoolControlle
 import { listPublicPoolsController } from '@/http/controllers/pools/listPublicPoolsController';
 import { removeUserFromPoolController } from '@/http/controllers/pools/removeUserFromPoolController';
 import { updatePoolController } from '@/http/controllers/pools/updatePoolController';
-import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { poolSchemas } from '@/http/schemas/pool.schemas';
 
 export function poolRoutes(app: FastifyInstance): void {
-  app.addHook('onRequest', verifyJwt);
+  app.addHook('onRequest', verifySupabaseToken);
 
   app.get(
     '/pools',

--- a/src/http/routes/predictions.routes.ts
+++ b/src/http/routes/predictions.routes.ts
@@ -3,12 +3,12 @@ import { FastifyInstance } from 'fastify';
 import { createPredictionController } from '@/http/controllers/predictions/createPredictionController';
 import { getPredictionController } from '@/http/controllers/predictions/getPredictionController';
 import { updatePredictionController } from '@/http/controllers/predictions/updatePredictionController';
-import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { predictionSchemas } from '@/http/schemas/prediction.schemas';
 
 export async function predictionsRoutes(app: FastifyInstance) {
-  app.addHook('onRequest', verifyJwt);
+  app.addHook('onRequest', verifySupabaseToken);
 
   app.post('/predictions', {
     schema: {

--- a/src/http/routes/tournaments.routes.ts
+++ b/src/http/routes/tournaments.routes.ts
@@ -2,13 +2,13 @@ import { FastifyInstance } from 'fastify';
 
 import { getTournamentMatchesController } from '@/http/controllers/tournaments/getTournamentMatchesController';
 import { listTournamentsController } from '@/http/controllers/tournaments/listTournamentsController';
-import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { matchSchemas } from '@/http/schemas/match.schemas';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { tournamentSchemas } from '@/http/schemas/tournament.schemas';
 
 export function tournamentsRoutes(app: FastifyInstance): void {
-  app.addHook('onRequest', verifyJwt);
+  app.addHook('onRequest', verifySupabaseToken);
 
   app.get(
     '/tournaments',

--- a/src/http/routes/user.routes.ts
+++ b/src/http/routes/user.routes.ts
@@ -7,12 +7,12 @@ import { getUserPoolsController } from '@/http/controllers/user/getUserPoolsCont
 import { getUserPoolsStandingsController } from '@/http/controllers/user/getUserPoolsStandingsController';
 import { getUserPredictionsController } from '@/http/controllers/user/getUserPredictionsController';
 import { updateUserController } from '@/http/controllers/user/updateUserController';
-import { verifyJwt } from '@/http/middlewares/verifyJwt';
+import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { userSchemas } from '@/http/schemas/user.schemas';
 
 export function userRoutes(app: FastifyInstance): void {
-  app.addHook('onRequest', verifyJwt);
+  app.addHook('onRequest', verifySupabaseToken);
 
   // Public route for user registration
   app.post(


### PR DESCRIPTION
## Summary
- add middleware to validate Supabase JWTs and attach user id
- apply new middleware across all route groups
- test middleware behavior for valid, missing and invalid tokens

## Testing
- `npx vitest run --config vitest.middleware.config.ts`
- `npm run lint` *(fails: There should be at least one empty line between import groups)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4940c79883289feeb0fac55eb912