### PR TITLE
feat: enforce invite code for private pools

### DIFF
--- a/src/http/controllers/pools/createPoolController.spec.ts
+++ b/src/http/controllers/pools/createPoolController.spec.ts
@@ -164,6 +164,22 @@ describe('Create Pool Controller (e2e)', async () => {
     expect(body.pool).toHaveProperty('inviteCode', 'TEST123');
   });
 
+  it('should return 422 when creating a private pool without an invite code', async () => {
+    const response = await request(app.server)
+      .post('/pools')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Private Pool No Code',
+        tournamentId,
+        isPrivate: true,
+      });
+
+    expect(response.statusCode).toBe(422);
+
+    const body = response.body as ErrorResponse;
+    expect(body).toHaveProperty('message', 'Validation error');
+  });
+
   it('should handle all required fields', async () => {
     const response = await request(app.server)
       .post('/pools')

--- a/src/http/controllers/pools/createPoolController.spec.ts
+++ b/src/http/controllers/pools/createPoolController.spec.ts
@@ -46,7 +46,7 @@ describe('Create Pool Controller (e2e)', async () => {
         name: 'Test Pool',
         description: 'This is a test pool',
         tournamentId,
-        isPrivate: true,
+        isPrivate: false,
         maxParticipants: 10,
         //registrationDeadline: new Date(Date.now() + 1000 * 60 * 60 * 24), // Tomorrow
       });
@@ -60,7 +60,7 @@ describe('Create Pool Controller (e2e)', async () => {
     expect(body.pool.description).toBe('This is a test pool');
     expect(body.pool.tournamentId).toBe(tournamentId);
     expect(body.pool.creatorId).toBe(userId);
-    expect(body.pool.isPrivate).toBe(true);
+    expect(body.pool.isPrivate).toBe(false);
     expect(body.pool.maxParticipants).toBe(10);
   });
 

--- a/src/http/controllers/pools/createPoolController.ts
+++ b/src/http/controllers/pools/createPoolController.ts
@@ -2,18 +2,27 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InviteCodeRequiredError } from '@/useCases/pools/errors/InviteCodeRequiredError';
 import { PoolNameInUseError } from '@/useCases/pools/errors/PoolNameInUseError';
 import { makeCreatePoolUseCase } from '@/useCases/pools/factory/makeCreatePoolUseCase';
 
-const createPoolBodySchema = z.object({
-  name: z.string().min(3),
-  description: z.string().optional(),
-  tournamentId: z.number(),
-  isPrivate: z.boolean().default(false),
-  maxParticipants: z.number().optional(),
-  inviteCode: z.string().optional(),
-  registrationDeadline: z.date().optional(),
-});
+const createPoolBodySchema = z
+  .object({
+    name: z.string().min(3),
+    description: z.string().optional(),
+    tournamentId: z.number(),
+    isPrivate: z.boolean().default(false),
+    maxParticipants: z.number().optional(),
+    inviteCode: z.string().optional(),
+    registrationDeadline: z.date().optional(),
+  })
+  .refine(
+    (data) => !data.isPrivate || !!data.inviteCode,
+    {
+      message: 'Invite code is required for private pools',
+      path: ['inviteCode'],
+    }
+  );
 
 type CreatePoolBody = z.infer<typeof createPoolBodySchema>;
 
@@ -56,6 +65,9 @@ export async function createPoolController(
     }
     if (error instanceof PoolNameInUseError) {
       return reply.status(409).send({ message: error.message });
+    }
+    if (error instanceof InviteCodeRequiredError) {
+      return reply.status(422).send({ message: error.message });
     }
 
     if (error instanceof z.ZodError) {

--- a/src/useCases/pools/createPoolUseCase.ts
+++ b/src/useCases/pools/createPoolUseCase.ts
@@ -1,8 +1,8 @@
-import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
-import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
-import { ITournamentsRepository } from '../../repositories/tournaments/ITournamentsRepository';
-import { IUsersRepository } from '../../repositories/users/IUsersRepository';
-// eslint-disable-next-line import/order
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { InviteCodeRequiredError } from './errors/InviteCodeRequiredError';
 import { PoolNameInUseError } from './errors/PoolNameInUseError';
 
 interface ICreatePoolRequest {
@@ -33,6 +33,10 @@ export class CreatePoolUseCase {
     registrationDeadline,
     inviteCode,
   }: ICreatePoolRequest) {
+    if (isPrivate && !inviteCode) {
+      throw new InviteCodeRequiredError();
+    }
+
     const creator = await this.usersRepository.findById(creatorId);
 
     if (!creator) {

--- a/src/useCases/pools/errors/InviteCodeRequiredError.ts
+++ b/src/useCases/pools/errors/InviteCodeRequiredError.ts
@@ -1,0 +1,7 @@
+export class InviteCodeRequiredError extends Error {
+  constructor() {
+    super('Invite code is required for private pools');
+    this.name = 'InviteCodeRequiredError';
+    Object.setPrototypeOf(this, InviteCodeRequiredError.prototype);
+  }
+}


### PR DESCRIPTION
## Summary
- require invite codes when creating private pools
- ensure use case enforces invite code presence
- test controller rejects private pools without invite codes

## Testing
- `npm run test:e2e -- src/http/controllers/pools/createPoolController.spec.ts` *(fails: Can't reach database server at `localhost:5432`)*
- `npm run lint` *(fails: 290 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68be970b5ec883288b928158e36da530