### PR TITLE
feat(pool): enforce unique invite codes

### DIFF
--- a/prisma/migrations/20250715090000_readd_pool_invitecode_unique/migration.sql
+++ b/prisma/migrations/20250715090000_readd_pool_invitecode_unique/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "pools_inviteCode_key" ON "pools"("inviteCode");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,7 +118,7 @@ model Pool {
   description          String?
   creatorId            String
   isPrivate            Boolean                  @default(false)
-  inviteCode           String?
+  inviteCode           String?                  @unique
   createdAt            DateTime                 @default(now())
   maxParticipants      Int?
   registrationDeadline DateTime?

--- a/src/global/errors/InviteCodeInUseError.ts
+++ b/src/global/errors/InviteCodeInUseError.ts
@@ -1,0 +1,7 @@
+export class InviteCodeInUseError extends Error {
+  constructor(info?: string) {
+    super(`Invite code already in use: ${info || ''}`);
+    this.name = 'InviteCodeInUseError';
+    Object.setPrototypeOf(this, InviteCodeInUseError.prototype);
+  }
+}

--- a/src/http/controllers/pools/createPoolController.spec.ts
+++ b/src/http/controllers/pools/createPoolController.spec.ts
@@ -164,6 +164,34 @@ describe('Create Pool Controller (e2e)', async () => {
     expect(body.pool).toHaveProperty('inviteCode', 'TEST123');
   });
 
+  it('should return 409 when invite code is already in use', async () => {
+    const inviteCode = 'DUPLICATE123';
+    await request(app.server)
+      .post('/pools')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        inviteCode,
+        name: 'First Pool',
+        tournamentId,
+        isPrivate: true,
+      });
+
+    const response = await request(app.server)
+      .post('/pools')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        inviteCode,
+        name: 'Second Pool',
+        tournamentId,
+        isPrivate: true,
+      });
+
+    expect(response.statusCode).toBe(409);
+
+    const body = response.body as ErrorResponse;
+    expect(body.message).toContain('Invite code already in use');
+  });
+
   it('should return 422 when creating a private pool without an invite code', async () => {
     const response = await request(app.server)
       .post('/pools')

--- a/src/http/controllers/pools/createPoolController.ts
+++ b/src/http/controllers/pools/createPoolController.ts
@@ -2,6 +2,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InviteCodeInUseError } from '@/global/errors/InviteCodeInUseError';
 import { InviteCodeRequiredError } from '@/useCases/pools/errors/InviteCodeRequiredError';
 import { PoolNameInUseError } from '@/useCases/pools/errors/PoolNameInUseError';
 import { makeCreatePoolUseCase } from '@/useCases/pools/factory/makeCreatePoolUseCase';
@@ -64,6 +65,9 @@ export async function createPoolController(
       return reply.status(404).send({ message: error.message });
     }
     if (error instanceof PoolNameInUseError) {
+      return reply.status(409).send({ message: error.message });
+    }
+    if (error instanceof InviteCodeInUseError) {
       return reply.status(409).send({ message: error.message });
     }
     if (error instanceof InviteCodeRequiredError) {

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -1,5 +1,6 @@
 import { Match, Pool, Prediction, Prisma, ScoringRule } from '@prisma/client';
 
+import { InviteCodeInUseError } from '@/global/errors/InviteCodeInUseError';
 import { PoolParticipant } from '@/global/types/poolParticipant';
 import { PoolStandings } from '@/global/types/poolStandings';
 import { PredictionPoints } from '@/global/types/predictionPoints';
@@ -170,6 +171,13 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
   }
 
   async create(data: Prisma.PoolCreateInput): Promise<Pool> {
+    if (data.inviteCode) {
+      const exists = this.pools.some((pool) => pool.inviteCode === data.inviteCode);
+      if (exists) {
+        throw new InviteCodeInUseError(data.inviteCode);
+      }
+    }
+
     const newId = this.pools.length + 1;
 
     const pool: Pool = {

--- a/src/test/mocks/pools.ts
+++ b/src/test/mocks/pools.ts
@@ -19,14 +19,15 @@ export async function createPool(
     registrationDeadline?: Date;
   }
 ): Promise<Pool> {
-  const randomPoolNumber = Math.floor(Math.random() * 100);
+  const randomPoolNumber = Math.floor(Math.random() * 1000000);
+  const generatedInviteCode = `invite-${faker.string.uuid()}`;
 
   const pool = await repository.create({
     name: data.name ?? `Pool ${randomPoolNumber}`,
     description: data.description ?? `Test pool description ${randomPoolNumber}`,
     tournament: { connect: { id: data.tournamentId ?? randomPoolNumber } },
     creator: { connect: { id: data.creatorId ?? `faker-${randomPoolNumber}` } },
-    inviteCode: data.inviteCode ?? `invite-${randomPoolNumber}`,
+    inviteCode: data.inviteCode ?? generatedInviteCode,
     isPrivate: data.isPrivate ?? false,
     maxParticipants: data.maxParticipants ?? 100,
     registrationDeadline: data.registrationDeadline ?? new Date(3025, 5, 24),


### PR DESCRIPTION
## Summary
- restore unique index on pools.inviteCode
- surface InviteCodeInUseError when duplicate codes are used
- test duplicate invite code rejection

## Testing
- `npm run lint` *(fails: import order violations in unrelated files)*
- `npm run test:run`
- `npm run test:e2e` *(fails: missing environment variables / database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68bea1f6dd8c8328965a07c57dc80bb4