### PR TITLE
feat: add pool invite lookup

### DIFF
--- a/src/http/controllers/pools/getPoolByInviteController.spec.ts
+++ b/src/http/controllers/pools/getPoolByInviteController.spec.ts
@@ -1,0 +1,75 @@
+import { Pool } from '@prisma/client';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { createTestApp } from '@/test/helper-e2e';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createPool } from '@/test/mocks/pools';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+
+type GetPoolByInviteResponse = {
+  pool: Pool;
+};
+
+describe('Get Pool By Invite Controller (e2e)', async () => {
+  const app = await createTestApp();
+  let token: string;
+  let tournamentId: number;
+
+  let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+  let usersRepository: IUsersRepository;
+
+  beforeAll(async () => {
+    ({ token } = await getSupabaseAccessToken(app));
+
+    poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+    usersRepository = new PrismaUsersRepository();
+
+    const tournament = await createTournament(tournamentsRepository, {});
+    tournamentId = tournament.id;
+  });
+
+  it('should return pool information for a valid invite code', async () => {
+    const poolCreator = await createUser(usersRepository, { email: 'creator@example.com' });
+    const pool = await createPool(poolsRepository, {
+      creatorId: poolCreator.id,
+      tournamentId,
+      name: 'Invite Pool',
+      inviteCode: 'INVITE-CODE',
+      isPrivate: true,
+    });
+
+    const response = await request(app.server)
+      .get(`/pool-invites/${pool.inviteCode}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
+    expect(response.statusCode).toEqual(200);
+    const body = response.body as GetPoolByInviteResponse;
+    expect(body.pool).toEqual(
+      expect.objectContaining({
+        id: pool.id,
+        name: 'Invite Pool',
+        inviteCode: 'INVITE-CODE',
+      })
+    );
+  });
+
+  it('should return 404 when invite code does not exist', async () => {
+    const response = await request(app.server)
+      .get('/pool-invites/NON-EXISTING')
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/src/http/controllers/pools/getPoolByInviteController.spec.ts
+++ b/src/http/controllers/pools/getPoolByInviteController.spec.ts
@@ -2,13 +2,13 @@ import { Pool } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/pools/getPoolByInviteController.ts
+++ b/src/http/controllers/pools/getPoolByInviteController.ts
@@ -1,0 +1,33 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { makeGetPoolByInviteUseCase } from '@/useCases/pools/factory/makeGetPoolByInviteUseCase';
+
+const getPoolByInviteParamsSchema = z.object({
+  inviteCode: z.string().min(1, 'Invite code is required'),
+});
+
+export async function getPoolByInviteController(
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<void> {
+  try {
+    const { inviteCode } = getPoolByInviteParamsSchema.parse(request.params);
+
+    const getPoolByInviteUseCase = makeGetPoolByInviteUseCase();
+    const pool = await getPoolByInviteUseCase.execute({ inviteCode });
+
+    return reply.status(200).send({ pool });
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return reply.status(404).send({ message: error.message });
+    }
+
+    if (error instanceof z.ZodError) {
+      return reply.status(422).send({ message: 'Validation error', issues: error.format() });
+    }
+
+    throw error;
+  }
+}

--- a/src/http/routes/pools.routes.ts
+++ b/src/http/routes/pools.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 
 import { createPoolController } from '@/http/controllers/pools/createPoolController';
+import { getPoolByInviteController } from '@/http/controllers/pools/getPoolByInviteController';
 import { getPoolController } from '@/http/controllers/pools/getPoolController';
 import { getPoolPredictionsController } from '@/http/controllers/pools/getPoolPredictionsController';
 import { getPoolStandingsController } from '@/http/controllers/pools/getPoolStandingsController';
@@ -153,6 +154,37 @@ export function poolRoutes(app: FastifyInstance): void {
       },
     },
     joinPoolByIdController
+  );
+
+  // Get pool by invite code (metadata only)
+  app.get(
+    '/pool-invites/:inviteCode',
+    {
+      schema: {
+        tags: ['Pools'],
+        summary: 'Get pool by invite code',
+        description: 'Retrieve pool information using its invitation code without joining',
+        params: poolSchemas.GetPoolByInviteParams,
+        response: {
+          200: {
+            description: 'Pool information retrieved successfully',
+            type: 'object',
+            properties: {
+              pool: poolSchemas.Pool,
+            },
+          },
+          404: {
+            description: 'Pool not found with this invite code',
+            ...commonSchemas.PoolNotFoundError,
+          },
+          422: {
+            description: 'Validation error',
+            ...poolSchemas.PoolValidationError,
+          },
+        },
+      },
+    },
+    getPoolByInviteController
   );
 
   // Join pool by invite code (works for both public and private pools)

--- a/src/http/schemas/pool.schemas.ts
+++ b/src/http/schemas/pool.schemas.ts
@@ -180,6 +180,18 @@ export const poolSchemas = {
     required: ['inviteCode'],
   },
 
+  GetPoolByInviteParams: {
+    type: 'object',
+    properties: {
+      inviteCode: {
+        type: 'string',
+        minLength: 1,
+        description: 'Pool invitation code',
+      },
+    },
+    required: ['inviteCode'],
+  },
+
   // Join Pool Response
   JoinPoolResponse: {
     type: 'object',

--- a/src/useCases/pools/factory/makeGetPoolByInviteUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolByInviteUseCase.ts
@@ -1,0 +1,10 @@
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+
+import { GetPoolByInviteUseCase } from '../getPoolByInviteUseCase';
+
+export function makeGetPoolByInviteUseCase(): GetPoolByInviteUseCase {
+  const poolsRepository = new PrismaPoolsRepository();
+  const tournamentsRepository = new PrismaTournamentsRepository();
+  return new GetPoolByInviteUseCase(poolsRepository, tournamentsRepository);
+}

--- a/src/useCases/pools/getPoolByInviteUseCase.spec.ts
+++ b/src/useCases/pools/getPoolByInviteUseCase.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { InMemoryTournamentsRepository } from '@/repositories/tournaments/InMemoryTournamentsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+
+import { GetPoolByInviteUseCase } from './getPoolByInviteUseCase';
+
+let poolsRepository: IPoolsRepository;
+let tournamentsRepository: ITournamentsRepository;
+let sut: GetPoolByInviteUseCase;
+
+describe('Get Pool By Invite Use Case', () => {
+  beforeEach(() => {
+    poolsRepository = new InMemoryPoolsRepository();
+    tournamentsRepository = new InMemoryTournamentsRepository();
+    sut = new GetPoolByInviteUseCase(poolsRepository, tournamentsRepository);
+  });
+
+  it('should return pool info by invite code with scoring rules, tournament and participants count', async () => {
+    const tournament = await tournamentsRepository.create({
+      name: 'World Cup',
+      startDate: new Date('2026-06-01'),
+      endDate: new Date('2026-07-31'),
+    });
+
+    const registrationDeadline = new Date('2026-05-01T00:00:00Z');
+
+    const pool = await poolsRepository.create({
+      name: 'Invite Pool',
+      description: 'Private pool',
+      tournament: { connect: { id: tournament.id } },
+      creator: { connect: { id: 'creator-1' } },
+      isPrivate: true,
+      inviteCode: 'INV-123',
+      maxParticipants: 100,
+      registrationDeadline,
+    });
+
+    await poolsRepository.createScoringRules({
+      pool: { connect: { id: pool.id } },
+      exactScorePoints: 5,
+      correctWinnerPoints: 3,
+      correctDrawPoints: 2,
+      correctWinnerGoalDiffPoints: 4,
+      specialEventPoints: 7,
+      knockoutMultiplier: 1.5,
+      finalMultiplier: 2.5,
+    });
+
+    await poolsRepository.addParticipant({ poolId: pool.id, userId: 'creator-1' });
+    await poolsRepository.addParticipant({ poolId: pool.id, userId: 'user-2' });
+
+    const result = await sut.execute({ inviteCode: 'INV-123' });
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe(pool.id);
+    expect(result.name).toBe('Invite Pool');
+    expect(result.description).toBe('Private pool');
+    expect(result.isPrivate).toBe(true);
+    expect(result.inviteCode).toBe('INV-123');
+    expect(result.maxParticipants).toBe(100);
+    expect(result.registrationDeadline?.getTime()).toBe(registrationDeadline.getTime());
+    expect(result.creatorId).toBe('creator-1');
+    expect(result.tournamentId).toBe(tournament.id);
+    expect(result.tournament).toEqual(expect.objectContaining({ id: tournament.id, name: 'World Cup' }));
+    expect(result.participantsCount).toBe(2);
+
+    expect(result.scoringRules).toEqual(
+      expect.objectContaining({
+        exactScorePoints: 5,
+        correctWinnerPoints: 3,
+        correctDrawPoints: 2,
+        correctWinnerGoalDiffPoints: 4,
+        knockoutMultiplier: 1.5,
+        finalMultiplier: 2.5,
+      })
+    );
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('should throw when invite code does not exist', async () => {
+    await expect(() => sut.execute({ inviteCode: 'DOES-NOT-EXIST' })).rejects.toBeInstanceOf(
+      ResourceNotFoundError
+    );
+  });
+
+  it('should throw when pool has no scoring rules', async () => {
+    const tournament = await tournamentsRepository.create({
+      name: 'World Cup',
+      startDate: new Date('2026-06-01'),
+      endDate: new Date('2026-07-31'),
+    });
+
+    await poolsRepository.create({
+      name: 'No Rules Pool',
+      tournament: { connect: { id: tournament.id } },
+      creator: { connect: { id: 'creator-1' } },
+      inviteCode: 'INV-NO-RULES',
+      isPrivate: false,
+    });
+
+    await expect(() => sut.execute({ inviteCode: 'INV-NO-RULES' })).rejects.toBeInstanceOf(
+      ResourceNotFoundError
+    );
+  });
+
+  it('should throw when tournament linked to pool does not exist', async () => {
+    const pool = await poolsRepository.create({
+      name: 'Orphan Tournament Pool',
+      tournament: { connect: { id: 999 } },
+      creator: { connect: { id: 'creator-1' } },
+      inviteCode: 'INV-ORPHAN',
+      isPrivate: false,
+    });
+
+    await poolsRepository.createScoringRules({
+      pool: { connect: { id: pool.id } },
+      exactScorePoints: 1,
+      correctWinnerPoints: 1,
+      correctDrawPoints: 1,
+      correctWinnerGoalDiffPoints: 1,
+      specialEventPoints: 0,
+      knockoutMultiplier: 1,
+      finalMultiplier: 1,
+    });
+
+    await expect(() => sut.execute({ inviteCode: 'INV-ORPHAN' })).rejects.toBeInstanceOf(
+      ResourceNotFoundError
+    );
+  });
+});
+

--- a/src/useCases/pools/getPoolByInviteUseCase.ts
+++ b/src/useCases/pools/getPoolByInviteUseCase.ts
@@ -1,0 +1,88 @@
+import { ScoringRule, Tournament } from '@prisma/client';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IPoolsRepository, PoolCompleteInfo } from '@/repositories/pools/IPoolsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+
+interface IGetPoolByInviteRequest {
+  inviteCode: string;
+}
+
+interface IGetPoolByInviteResponse {
+  id: number;
+  name: string;
+  description?: string;
+  isPrivate: boolean;
+  maxParticipants?: number;
+  registrationDeadline?: Date;
+  createdAt: Date;
+  creatorId: string;
+  tournamentId: number;
+  inviteCode?: string | null; // include to maintain compatibility
+  scoringRules: {
+    exactScorePoints: number;
+    correctWinnerPoints: number;
+    correctDrawPoints: number;
+    correctWinnerGoalDiffPoints: number;
+    finalMultiplier: number;
+    knockoutMultiplier: number;
+  };
+  tournament?: Tournament;
+  participantsCount: number;
+}
+
+export class GetPoolByInviteUseCase {
+  constructor(
+    private poolsRepository: IPoolsRepository,
+    private tournamentsRepository: ITournamentsRepository
+  ) {}
+
+  async execute({ inviteCode }: IGetPoolByInviteRequest): Promise<IGetPoolByInviteResponse> {
+    const poolByCode = await this.poolsRepository.findByInviteCode(inviteCode);
+    if (!poolByCode) {
+      throw new ResourceNotFoundError('Pool not found with this invite code');
+    }
+
+    const pool = await this.poolsRepository.getPool(poolByCode.id);
+    if (!pool || !pool.scoringRules) {
+      throw new ResourceNotFoundError('Pool not found');
+    }
+
+    const tournament = await this.tournamentsRepository.findById(pool.tournamentId);
+    if (!tournament) {
+      throw new ResourceNotFoundError('Tournament not found');
+    }
+
+    return this.mapToResponse(pool, pool.scoringRules, tournament);
+  }
+
+  private mapToResponse(
+    pool: PoolCompleteInfo,
+    scoringRules: ScoringRule,
+    tournament: Tournament
+  ): IGetPoolByInviteResponse {
+    return {
+      id: pool.id,
+      name: pool.name,
+      description: pool.description ?? undefined,
+      isPrivate: pool.isPrivate,
+      maxParticipants: pool.maxParticipants ?? undefined,
+      registrationDeadline: pool.registrationDeadline ?? undefined,
+      createdAt: pool.createdAt,
+      creatorId: pool.creatorId,
+      tournamentId: pool.tournamentId,
+      inviteCode: pool.inviteCode,
+      scoringRules: {
+        exactScorePoints: scoringRules.exactScorePoints,
+        correctWinnerPoints: scoringRules.correctWinnerPoints,
+        correctDrawPoints: scoringRules.correctDrawPoints,
+        correctWinnerGoalDiffPoints: scoringRules.correctWinnerGoalDiffPoints,
+        finalMultiplier: scoringRules.finalMultiplier.toNumber(),
+        knockoutMultiplier: scoringRules.knockoutMultiplier.toNumber(),
+      },
+      tournament: tournament,
+      participantsCount: pool.participants.length,
+    };
+  }
+}
+


### PR DESCRIPTION
## Summary
- expose GET /pool-invites/:inviteCode to fetch pool details
- implement controller and use case for invite-based retrieval
- cover pool lookup and 404 cases with e2e tests

## Testing
- `npm run lint` *(fails: There should be at least one empty line between import groups)*
- `npm run test:e2e -- src/http/controllers/pools/getPoolByInviteController.spec.ts` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe56cdf7c83289576a97783e5400f