### PR TITLE
feat: make test env vars optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,6 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Database
 DATABASE_URL=postgresql://docker:docker@localhost:5432/bolao
 
-# Test helpers
+# Test helpers (only required when NODE_ENV=test)
 TEST_USER_EMAIL=
 TEST_USER_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Setup
 
 1. Copy `.env.example` to `.env`.
-2. Provide values for Supabase keys, database credentials, and other variables before running the app.
+2. Provide values for Supabase keys, database credentials, and other variables before running the app. `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` are only needed when `NODE_ENV` is `test`.
 
 ## Development
 

--- a/src/env/config.ts
+++ b/src/env/config.ts
@@ -19,8 +19,25 @@ const envSchema = z.object({
   LOG_LEVEL: z.string().default('info'),
   SUPABASE_URL: z.string(),
   SUPABASE_ANON_KEY: z.string(),
-  TEST_USER_PASSWORD: z.string(),
-  TEST_USER_EMAIL: z.string(),
+  TEST_USER_PASSWORD: z.string().optional(),
+  TEST_USER_EMAIL: z.string().optional(),
+}).superRefine((data, ctx) => {
+  if (data.NODE_ENV === 'test') {
+    if (!data.TEST_USER_EMAIL) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'TEST_USER_EMAIL is required when NODE_ENV is test',
+        path: ['TEST_USER_EMAIL'],
+      });
+    }
+    if (!data.TEST_USER_PASSWORD) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'TEST_USER_PASSWORD is required when NODE_ENV is test',
+        path: ['TEST_USER_PASSWORD'],
+      });
+    }
+  }
 });
 
 const _env = envSchema.safeParse(process.env);


### PR DESCRIPTION
## Summary
- require TEST_USER_EMAIL and TEST_USER_PASSWORD only for test environment
- document that test helper env vars are optional in production

## Testing
- `npm run lint` *(fails: import order and other lint errors across repository)*
- `npm run test:run`
- `npm run test:e2e` *(fails: missing env vars and database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c28e84ffe08328bfeac16d2068bbd1