### PR TITLE
Refactor imports and clean up code across multiple use cases and tests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -43,9 +43,9 @@ export const createServer = async (): Promise<FastifyInstance> => {
   const { tournamentSchemas } = await import('./http/schemas/tournament.schemas');
 
   // Combine all schemas and remove duplicates
-  const allSchemas: Record<string, any> = {};
+  const allSchemas: Record<string, unknown> = {};
 
-  const mergeSchemas = (schemas: Record<string, any>) => {
+  const mergeSchemas = (schemas: Record<string, unknown>) => {
     Object.entries(schemas).forEach(([key, schema]) => {
       if (allSchemas[key]) {
         server.log.warn(`Duplicate schema detected for ${key}, keeping existing definition.`);

--- a/src/env/config.ts
+++ b/src/env/config.ts
@@ -1,6 +1,5 @@
 import { config } from 'dotenv';
 // import 'dotenv/config';
-
 import { z } from 'zod';
 
 if (process.env.NODE_ENV === 'test') {

--- a/src/global/errors/EmailInUseError.ts
+++ b/src/global/errors/EmailInUseError.ts
@@ -1,5 +1,5 @@
 export class EmailInUseError extends Error {
-  constructor(info?: string | undefined) {
+  constructor(info?: string  ) {
     super(`Email already in use. ${info}`);
     this.name = 'EmailInUseError';
     Object.setPrototypeOf(this, EmailInUseError.prototype);

--- a/src/http/controllers/matches/getMatchController.spec.ts
+++ b/src/http/controllers/matches/getMatchController.spec.ts
@@ -14,10 +14,9 @@ import { createMatch, createMatchWithTeams } from '@/test/mocks/match';
 import { createTeam } from '@/test/mocks/teams';
 import { createTournament } from '@/test/mocks/tournament';
 
-describe('Get Match Controller (e2e)', async () => {
+describe('Get Match Controller (e2e)', () => {
   let app: FastifyInstance;
 
-  let userId: string;
   let token: string;
 
   let matchesRepository: IMatchesRepository;
@@ -26,7 +25,7 @@ describe('Get Match Controller (e2e)', async () => {
 
   beforeAll(async () => {
     app = await createTestApp();
-    ({ token, userId } = await getSupabaseAccessToken(app));
+    ({ token } = await getSupabaseAccessToken(app));
     matchesRepository = new PrismaMatchesRepository();
     teamsRepository = new PrismaTeamsRepository();
     tournamentsRepository = new PrismaTournamentsRepository();
@@ -61,13 +60,22 @@ describe('Get Match Controller (e2e)', async () => {
       .send();
 
     expect(response.statusCode).toEqual(200);
-    expect(response.body).toHaveProperty('match');
-    expect(response.body.match).toHaveProperty('id', match.id);
-    expect(response.body.match).toHaveProperty('homeTeam');
-    expect(response.body.match).toHaveProperty('awayTeam');
-    expect(response.body.match).toHaveProperty('tournament');
-    expect(response.body.match.homeTeam.id).toEqual(homeTeam.id);
-    expect(response.body.match.awayTeam.id).toEqual(awayTeam.id);
+    type MatchResponse = {
+      match: {
+        id: number;
+        homeTeam: { id: number };
+        awayTeam: { id: number };
+        tournament?: unknown;
+      };
+    };
+    const body = response.body as unknown as MatchResponse;
+    expect(body).toHaveProperty('match');
+    expect(body.match).toHaveProperty('id', match.id);
+    expect(body.match).toHaveProperty('homeTeam');
+    expect(body.match).toHaveProperty('awayTeam');
+    expect(body.match).toHaveProperty('tournament');
+    expect(body.match.homeTeam.id).toEqual(homeTeam.id);
+    expect(body.match.awayTeam.id).toEqual(awayTeam.id);
   });
 
   it('should be able to get a match with teams in a single call', async () => {
@@ -94,12 +102,20 @@ describe('Get Match Controller (e2e)', async () => {
       .send();
 
     expect(response.statusCode).toEqual(200);
-    expect(response.body).toHaveProperty('match');
-    expect(response.body.match).toHaveProperty('id', match.id);
-    expect(response.body.match).toHaveProperty('homeTeam');
-    expect(response.body.match).toHaveProperty('awayTeam');
-    expect(response.body.match.homeTeam.id).toEqual(homeTeam.id);
-    expect(response.body.match.awayTeam.id).toEqual(awayTeam.id);
+    type MatchResponse2 = {
+      match: {
+        id: number;
+        homeTeam: { id: number };
+        awayTeam: { id: number };
+      };
+    };
+    const body2 = response.body as unknown as MatchResponse2;
+    expect(body2).toHaveProperty('match');
+    expect(body2.match).toHaveProperty('id', match.id);
+    expect(body2.match).toHaveProperty('homeTeam');
+    expect(body2.match).toHaveProperty('awayTeam');
+    expect(body2.match.homeTeam.id).toEqual(homeTeam.id);
+    expect(body2.match.awayTeam.id).toEqual(awayTeam.id);
   });
 
   it('should return 404 when match does not exist', async () => {

--- a/src/http/controllers/matches/getMatchController.ts
+++ b/src/http/controllers/matches/getMatchController.ts
@@ -1,7 +1,8 @@
-import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
-import { makeGetMatchUseCase } from '@/useCases/matches/factories/makeGetMatchUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { makeGetMatchUseCase } from '@/useCases/matches/factories/makeGetMatchUseCase';
 
 export async function getMatchController(
   request: FastifyRequest<{

--- a/src/http/controllers/matches/getMatchPredictionsController.spec.ts
+++ b/src/http/controllers/matches/getMatchPredictionsController.spec.ts
@@ -1,7 +1,6 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { predictionSchemas } from '@/http/schemas/prediction.schemas';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
@@ -15,6 +14,7 @@ import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsR
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createMatch } from '@/test/mocks/match';
 import { createPool } from '@/test/mocks/pools';

--- a/src/http/controllers/pools/createPoolController.ts
+++ b/src/http/controllers/pools/createPoolController.ts
@@ -1,8 +1,8 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 
-import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InviteCodeInUseError } from '@/global/errors/InviteCodeInUseError';
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InviteCodeRequiredError } from '@/useCases/pools/errors/InviteCodeRequiredError';
 import { PoolNameInUseError } from '@/useCases/pools/errors/PoolNameInUseError';
 import { makeCreatePoolUseCase } from '@/useCases/pools/factory/makeCreatePoolUseCase';

--- a/src/http/controllers/pools/getPoolController.spec.ts
+++ b/src/http/controllers/pools/getPoolController.spec.ts
@@ -2,13 +2,13 @@ import { Pool, ScoringRule, Tournament } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool, createPoolWithParticipants } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/pools/getPoolPredictionsController.spec.ts
+++ b/src/http/controllers/pools/getPoolPredictionsController.spec.ts
@@ -2,7 +2,6 @@ import { Match, Pool, Prediction } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
@@ -15,6 +14,7 @@ import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsR
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createMatch } from '@/test/mocks/match';
 import { createPool } from '@/test/mocks/pools';

--- a/src/http/controllers/pools/getPoolStandingsController.spec.ts
+++ b/src/http/controllers/pools/getPoolStandingsController.spec.ts
@@ -1,7 +1,6 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { PoolStandings } from '@/global/types/poolStandings';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
@@ -9,6 +8,7 @@ import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsR
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool, createPoolWithParticipants } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/pools/getPoolUsersController.spec.ts
+++ b/src/http/controllers/pools/getPoolUsersController.spec.ts
@@ -2,13 +2,13 @@ import { User } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool, createPoolWithParticipants } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/pools/joinPoolByIdController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByIdController.spec.ts
@@ -2,13 +2,13 @@ import { Pool } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/pools/joinPoolByInviteController.spec.ts
+++ b/src/http/controllers/pools/joinPoolByInviteController.spec.ts
@@ -2,13 +2,13 @@ import { Pool } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/pools/leavePoolController.spec.ts
+++ b/src/http/controllers/pools/leavePoolController.spec.ts
@@ -1,13 +1,13 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';
@@ -63,7 +63,8 @@ describe('Leave Pool Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(404);
-    expect(response.body).toHaveProperty('message');
+    const body = response.body as unknown as { message: string };
+    expect(body).toHaveProperty('message');
   });
 
   it('should return 403 when trying to leave a pool that user is not a participant of', async () => {
@@ -83,8 +84,9 @@ describe('Leave Pool Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(403);
-    expect(response.body).toHaveProperty('message');
-    expect(response.body.message).toContain('not a participant');
+    const body2 = response.body as unknown as { message: string };
+    expect(body2).toHaveProperty('message');
+    expect(body2.message).toContain('not a participant');
   });
 
   it('should return 403 when trying to leave a pool as the owner', async () => {
@@ -102,8 +104,9 @@ describe('Leave Pool Controller (e2e)', async () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(response.statusCode).toEqual(403);
-    expect(response.body).toHaveProperty('message');
-    expect(response.body.message).toContain(
+    const body3 = response.body as unknown as { message: string };
+    expect(body3).toHaveProperty('message');
+    expect(body3.message).toContain(
       'Unauthorized: Pool creator cannot leave their own pool'
     );
   });

--- a/src/http/controllers/pools/leavePoolController.ts
+++ b/src/http/controllers/pools/leavePoolController.ts
@@ -1,9 +1,10 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { NotParticipantError } from '@/useCases/pools/errors/NotParticipantError';
 import { UnauthorizedError } from '@/useCases/pools/errors/UnauthorizedError';
 import { makeLeavePoolUseCase } from '@/useCases/pools/factory/makeLeavePoolUseCase';
-import { FastifyReply, FastifyRequest } from 'fastify';
-import { z } from 'zod';
 
 export async function leavePoolController(request: FastifyRequest, reply: FastifyReply) {
   const leavePoolParamsSchema = z.object({

--- a/src/http/controllers/pools/removeUserFromPoolController.spec.ts
+++ b/src/http/controllers/pools/removeUserFromPoolController.spec.ts
@@ -1,13 +1,13 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createPool } from '@/test/mocks/pools';
 import { createTournament } from '@/test/mocks/tournament';

--- a/src/http/controllers/user/getLoggedUserInfoController.spec.ts
+++ b/src/http/controllers/user/getLoggedUserInfoController.spec.ts
@@ -1,8 +1,8 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { env } from '@/env/config';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 
 describe('Get User Info (e2e)', async () => {

--- a/src/http/controllers/user/getUserInfoController.spec.ts
+++ b/src/http/controllers/user/getUserInfoController.spec.ts
@@ -1,17 +1,16 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, test } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { prisma } from '@/lib/prisma';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 
 describe('Get User Info (e2e)', async () => {
   const app = await createTestApp();
-  let userId: string;
   let token: string;
 
   beforeAll(async () => {
-    ({ token, userId } = await getSupabaseAccessToken(app));
+    ({ token } = await getSupabaseAccessToken(app));
   });
 
 
@@ -31,7 +30,10 @@ describe('Get User Info (e2e)', async () => {
       .send();
 
     expect(response.statusCode).toEqual(200);
-    expect(response.body.user).toEqual(
+    const body = response.body as unknown as {
+      user: { email: string; fullName: string; accountProvider: string };
+    };
+    expect(body.user).toEqual(
       expect.objectContaining({
         email: 'test@example.com',
         fullName: 'Test User',
@@ -47,8 +49,7 @@ describe('Get User Info (e2e)', async () => {
       .send();
 
     expect(response.statusCode).toBe(404);
-    expect(response.body).toEqual({
-      message: expect.stringContaining('Resource not found'),
-    });
+    const body404 = response.body as unknown as { message: string };
+    expect(body404.message).toContain('Resource not found');
   });
 });

--- a/src/http/controllers/user/getUserPoolsController.ts
+++ b/src/http/controllers/user/getUserPoolsController.ts
@@ -1,7 +1,8 @@
-import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
-import { makeGetUserPoolsUseCase } from '@/useCases/pools/factory/makeGetUserPoolsUseCase';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { makeGetUserPoolsUseCase } from '@/useCases/pools/factory/makeGetUserPoolsUseCase';
 
 export async function getUserPoolsController(
   request: FastifyRequest<{ Params: { userId: string } }>,

--- a/src/http/controllers/user/getUserPoolsStandingsController.spec.ts
+++ b/src/http/controllers/user/getUserPoolsStandingsController.spec.ts
@@ -1,7 +1,6 @@
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { createTestApp } from '@/test/helper-e2e';
 import { PoolStandings } from '@/global/types/poolStandings';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
@@ -13,6 +12,7 @@ import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
 import { PrismaTeamsRepository } from '@/repositories/teams/PrismaTeamsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { createTestApp } from '@/test/helper-e2e';
 import { getSupabaseAccessToken } from '@/test/mockJwt';
 import { createMatchWithTeams } from '@/test/mocks/match';
 import { createPool } from '@/test/mocks/pools';

--- a/src/http/middlewares/verifyJwt.ts
+++ b/src/http/middlewares/verifyJwt.ts
@@ -11,7 +11,7 @@ export async function verifyJwt(request: FastifyRequest, reply: FastifyReply) {
     request.user = {
       sub: (payload as { sub: string }).sub,
     };
-  } catch (error) {
+  } catch {
     return reply.status(401).send({ message: 'Unauthorized.' });
   }
 }

--- a/src/http/routes/predictions.routes.ts
+++ b/src/http/routes/predictions.routes.ts
@@ -7,7 +7,7 @@ import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { predictionSchemas } from '@/http/schemas/prediction.schemas';
 
-export async function predictionsRoutes(app: FastifyInstance) {
+export function predictionsRoutes(app: FastifyInstance) {
   app.addHook('onRequest', verifySupabaseToken);
 
   app.post('/predictions', {

--- a/src/http/routes/tournaments.routes.ts
+++ b/src/http/routes/tournaments.routes.ts
@@ -3,8 +3,8 @@ import { FastifyInstance } from 'fastify';
 import { getTournamentMatchesController } from '@/http/controllers/tournaments/getTournamentMatchesController';
 import { listTournamentsController } from '@/http/controllers/tournaments/listTournamentsController';
 import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
-import { matchSchemas } from '@/http/schemas/match.schemas';
 import { commonSchemas } from '@/http/schemas/common.schemas';
+import { matchSchemas } from '@/http/schemas/match.schemas';
 import { tournamentSchemas } from '@/http/schemas/tournament.schemas';
 
 export function tournamentsRoutes(app: FastifyInstance): void {

--- a/src/http/routes/user.routes.ts
+++ b/src/http/routes/user.routes.ts
@@ -9,6 +9,7 @@ import { getUserPredictionsController } from '@/http/controllers/user/getUserPre
 import { updateUserController } from '@/http/controllers/user/updateUserController';
 import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
+import { predictionSchemas } from '@/http/schemas/prediction.schemas';
 import { userSchemas } from '@/http/schemas/user.schemas';
 
 export function userRoutes(app: FastifyInstance): void {
@@ -182,7 +183,7 @@ export function userRoutes(app: FastifyInstance): void {
             properties: {
               predictions: {
                 type: 'array',
-                items: userSchemas.Prediction,
+                items: predictionSchemas.Prediction,
               },
             },
           },

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+
 import { env } from '../env/config';
 
 export const prisma = new PrismaClient({

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+
 import { env } from '../env/config';
 
 export const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY);

--- a/src/repositories/matches/InMemoryMatchesRepository.ts
+++ b/src/repositories/matches/InMemoryMatchesRepository.ts
@@ -1,4 +1,5 @@
 import { Match, MatchStage, MatchStatus, Prisma, Team, Tournament } from '@prisma/client';
+
 import { IMatchesRepository } from './IMatchesRepository';
 
 export class InMemoryMatchesRepository implements IMatchesRepository {
@@ -6,7 +7,7 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
   public teams: Team[] = [];
   public tournaments: Tournament[] = [];
 
-  async create(data: Prisma.MatchCreateInput): Promise<Match> {
+  create(data: Prisma.MatchCreateInput): Promise<Match> {
     const newId = this.matches.length + 1;
 
     const match: Match = {
@@ -29,23 +30,23 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
     };
 
     this.matches.push(match);
-    return match;
+    return Promise.resolve(match);
   }
 
-  async findById(id: number): Promise<Match | null> {
+  findById(id: number): Promise<Match | null> {
     const match = this.matches.find((match) => match.id === id);
-    return match || null;
+    return Promise.resolve(match || null);
   }
 
-  async findByTournamentId(tournamentId: number): Promise<Match[]> {
+  findByTournamentId(tournamentId: number): Promise<Match[]> {
     const matches = this.matches
       .filter((match) => match.tournamentId === tournamentId)
       .sort((a, b) => a.matchDatetime.getTime() - b.matchDatetime.getTime());
 
-    return matches;
+    return Promise.resolve(matches);
   }
 
-  async findUpcomingMatches(tournamentId: number): Promise<Match[]> {
+  findUpcomingMatches(tournamentId: number): Promise<Match[]> {
     const matches = this.matches
       .filter(
         (match) =>
@@ -53,10 +54,10 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
       )
       .sort((a, b) => a.matchDatetime.getTime() - b.matchDatetime.getTime());
 
-    return matches;
+    return Promise.resolve(matches);
   }
 
-  async findCompletedMatches(tournamentId: number): Promise<Match[]> {
+  findCompletedMatches(tournamentId: number): Promise<Match[]> {
     const matches = this.matches
       .filter(
         (match) =>
@@ -64,10 +65,10 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
       )
       .sort((a, b) => b.matchDatetime.getTime() - a.matchDatetime.getTime());
 
-    return matches;
+    return Promise.resolve(matches);
   }
 
-  async update(id: number, data: Prisma.MatchUpdateInput): Promise<Match> {
+  update(id: number, data: Prisma.MatchUpdateInput): Promise<Match> {
     const matchIndex = this.matches.findIndex((match) => match.id === id);
 
     if (matchIndex === -1) {
@@ -106,10 +107,10 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
     };
 
     this.matches[matchIndex] = updatedMatch;
-    return updatedMatch;
+    return Promise.resolve(updatedMatch);
   }
 
-  async getMatchWithTeams(id: number): Promise<Match | null> {
+  getMatchWithTeams(id: number): Promise<Match | null> {
     const match = this.matches.find((match) => match.id === id);
 
     if (!match) {
@@ -124,11 +125,11 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
     const tournament = this.tournaments.find((tournament) => tournament.id === match.tournamentId);
 
     // Create a new object that includes the match and its related entities
-    return {
+    return Promise.resolve({
       ...match,
       homeTeam,
       awayTeam,
       tournament,
-    } as unknown as Match;
+    } as unknown as Match);
   }
 }

--- a/src/repositories/matches/PrismaMatchesRepository.ts
+++ b/src/repositories/matches/PrismaMatchesRepository.ts
@@ -1,6 +1,7 @@
 import { Match, MatchStatus, Prisma } from '@prisma/client';
-import { prisma } from '../../lib/prisma';
+
 import { IMatchesRepository } from './IMatchesRepository';
+import { prisma } from '../../lib/prisma';
 
 export class PrismaMatchesRepository implements IMatchesRepository {
   async create(data: Prisma.MatchCreateInput): Promise<Match> {

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -340,7 +340,7 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
     const startIndex = (page - 1) * perPage;
     const endIndex = startIndex + perPage;
 
-    return pools.slice(startIndex, endIndex);
+    return Promise.resolve(pools.slice(startIndex, endIndex));
   }
 
   async removeParticipant({ poolId, userId }: { poolId: number; userId: string }) {

--- a/src/repositories/predictions/InMemoryPredictionsRepository.ts
+++ b/src/repositories/predictions/InMemoryPredictionsRepository.ts
@@ -1,10 +1,11 @@
 import { Prediction, Prisma } from '@prisma/client';
+
 import { IPredictionsRepository } from './IPredictionsRepository';
 
 export class InMemoryPredictionsRepository implements IPredictionsRepository {
   public predictions: Prediction[] = [];
 
-  async create(data: Prisma.PredictionCreateInput): Promise<Prediction> {
+  create(data: Prisma.PredictionCreateInput): Promise<Prediction> {
     const newId = this.predictions.length + 1;
 
     const prediction: Prediction = {
@@ -12,8 +13,8 @@ export class InMemoryPredictionsRepository implements IPredictionsRepository {
       poolId: data.pool.connect?.id as number,
       matchId: data.match.connect?.id as number,
       userId: data.user.connect?.id as string,
-      predictedHomeScore: data.predictedHomeScore as number,
-      predictedAwayScore: data.predictedAwayScore as number,
+      predictedHomeScore: data.predictedHomeScore,
+      predictedAwayScore: data.predictedAwayScore,
       predictedHasExtraTime: (data.predictedHasExtraTime as boolean) || false,
       predictedHasPenalties: (data.predictedHasPenalties as boolean) || false,
       predictedPenaltyHomeScore: data.predictedPenaltyHomeScore as number | null,
@@ -24,15 +25,15 @@ export class InMemoryPredictionsRepository implements IPredictionsRepository {
     };
 
     this.predictions.push(prediction);
-    return prediction;
+    return Promise.resolve(prediction);
   }
 
-  async findById(id: number): Promise<Prediction | null> {
+  findById(id: number): Promise<Prediction | null> {
     const prediction = this.predictions.find((prediction) => prediction.id === id);
-    return prediction || null;
+    return Promise.resolve(prediction || null);
   }
 
-  async findByUserMatchAndPool(
+  findByUserMatchAndPool(
     userId: string,
     matchId: number,
     poolId: number
@@ -44,10 +45,10 @@ export class InMemoryPredictionsRepository implements IPredictionsRepository {
         prediction.poolId === poolId
     );
 
-    return prediction || null;
+    return Promise.resolve(prediction || null);
   }
 
-  async update(id: number, data: Prisma.PredictionUpdateInput): Promise<Prediction> {
+  update(id: number, data: Prisma.PredictionUpdateInput): Promise<Prediction> {
     const predictionIndex = this.predictions.findIndex((prediction) => prediction.id === id);
 
     if (predictionIndex === -1) {
@@ -90,33 +91,34 @@ export class InMemoryPredictionsRepository implements IPredictionsRepository {
     };
 
     this.predictions[predictionIndex] = updatedPrediction;
-    return updatedPrediction;
+    return Promise.resolve(updatedPrediction);
   }
 
-  async delete(id: number): Promise<void> {
+  delete(id: number): Promise<void> {
     const predictionIndex = this.predictions.findIndex((prediction) => prediction.id === id);
 
     if (predictionIndex !== -1) {
       this.predictions.splice(predictionIndex, 1);
     }
+    return Promise.resolve();
   }
 
-  async findByMatchId(matchId: number): Promise<Prediction[]> {
+  findByMatchId(matchId: number): Promise<Prediction[]> {
     const predictions = this.predictions.filter((item) => item.matchId === matchId);
-    return predictions;
+    return Promise.resolve(predictions);
   }
 
-  async findByUserId(userId: string, poolId?: number): Promise<Prediction[]> {
+  findByUserId(userId: string, poolId?: number): Promise<Prediction[]> {
     let predictions = this.predictions.filter((prediction) => prediction.userId === userId);
 
     if (poolId) {
       predictions = predictions.filter((prediction) => prediction.poolId === poolId);
     }
 
-    return predictions;
+    return Promise.resolve(predictions);
   }
 
-  async findByPoolId(poolId: number): Promise<Prediction[]> {
-    return this.predictions.filter((prediction) => prediction.poolId === poolId);
+  findByPoolId(poolId: number): Promise<Prediction[]> {
+    return Promise.resolve(this.predictions.filter((prediction) => prediction.poolId === poolId));
   }
 }

--- a/src/repositories/predictions/PrismaPredictionsRepository.ts
+++ b/src/repositories/predictions/PrismaPredictionsRepository.ts
@@ -1,6 +1,7 @@
 import { Prediction, Prisma } from '@prisma/client';
-import { prisma } from '../../lib/prisma';
+
 import { IPredictionsRepository } from './IPredictionsRepository';
+import { prisma } from '../../lib/prisma';
 
 export class PrismaPredictionsRepository implements IPredictionsRepository {
   async create(data: Prisma.PredictionCreateInput): Promise<Prediction> {

--- a/src/repositories/teams/InMemoryTeamsRepository.ts
+++ b/src/repositories/teams/InMemoryTeamsRepository.ts
@@ -1,11 +1,12 @@
 import { Prisma, Team } from '@prisma/client';
+
 import { ITeamsRepository } from './ITeamsRepository';
 
 export class InMemoryTeamsRepository implements ITeamsRepository {
   public items: Team[] = [];
   private tournamentTeams: { tournamentId: number; teamId: number; groupName?: string }[] = [];
 
-  async create(data: Prisma.TeamCreateInput): Promise<Team> {
+  create(data: Prisma.TeamCreateInput): Promise<Team> {
     const team = {
       id: this.items.length + 1,
       name: data.name,
@@ -16,34 +17,34 @@ export class InMemoryTeamsRepository implements ITeamsRepository {
 
     this.items.push(team);
 
-    return team;
+    return Promise.resolve(team);
   }
 
-  async findById(id: number): Promise<Team | null> {
+  findById(id: number): Promise<Team | null> {
     const team = this.items.find((item) => item.id === id);
 
     if (!team) {
       return null;
     }
 
-    return team;
+    return Promise.resolve(team);
   }
 
-  async findByName(name: string): Promise<Team | null> {
+  findByName(name: string): Promise<Team | null> {
     const team = this.items.find((item) => item.name === name);
 
     if (!team) {
       return null;
     }
 
-    return team;
+    return Promise.resolve(team);
   }
 
-  async findAll(): Promise<Team[]> {
-    return this.items.sort((a, b) => a.name.localeCompare(b.name));
+  findAll(): Promise<Team[]> {
+    return Promise.resolve(this.items.sort((a, b) => a.name.localeCompare(b.name)));
   }
 
-  async update(id: number, data: Prisma.TeamUpdateInput): Promise<Team> {
+  update(id: number, data: Prisma.TeamUpdateInput): Promise<Team> {
     const teamIndex = this.items.findIndex((item) => item.id === id);
 
     if (teamIndex === -1) {
@@ -69,10 +70,10 @@ export class InMemoryTeamsRepository implements ITeamsRepository {
             : team.flagUrl,
     };
 
-    return this.items[teamIndex];
+    return Promise.resolve(this.items[teamIndex]);
   }
 
-  async delete(id: number): Promise<void> {
+  delete(id: number): Promise<void> {
     const teamIndex = this.items.findIndex((item) => item.id === id);
 
     if (teamIndex === -1) {
@@ -83,26 +84,31 @@ export class InMemoryTeamsRepository implements ITeamsRepository {
 
     // Also remove any tournament associations
     this.tournamentTeams = this.tournamentTeams.filter((item) => item.teamId !== id);
+    return Promise.resolve();
   }
 
-  async findByCountryCode(countryCode: string): Promise<Team[]> {
-    return this.items
-      .filter((item) => item.countryCode === countryCode)
-      .sort((a, b) => a.name.localeCompare(b.name));
+  findByCountryCode(countryCode: string): Promise<Team[]> {
+    return Promise.resolve(
+      this.items
+        .filter((item) => item.countryCode === countryCode)
+        .sort((a, b) => a.name.localeCompare(b.name))
+    );
   }
 
-  async findByTournamentId(tournamentId: number): Promise<Team[]> {
+  findByTournamentId(tournamentId: number): Promise<Team[]> {
     const teamIds = this.tournamentTeams
       .filter((item) => item.tournamentId === tournamentId)
       .map((item) => item.teamId);
 
-    return this.items
-      .filter((item) => teamIds.includes(item.id))
-      .sort((a, b) => a.name.localeCompare(b.name));
+    return Promise.resolve(
+      this.items
+        .filter((item) => teamIds.includes(item.id))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    );
   }
 
   // Helper method for testing to associate teams with tournaments
-  async associateTeamWithTournament(
+  associateTeamWithTournament(
     teamId: number,
     tournamentId: number,
     groupName?: string
@@ -112,5 +118,6 @@ export class InMemoryTeamsRepository implements ITeamsRepository {
       tournamentId,
       groupName,
     });
+    return Promise.resolve();
   }
 }

--- a/src/repositories/teams/PrismaTeamsRepository.ts
+++ b/src/repositories/teams/PrismaTeamsRepository.ts
@@ -1,5 +1,7 @@
-import { prisma } from '@/lib/prisma';
 import { Prisma, Team } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
 import { ITeamsRepository } from './ITeamsRepository';
 
 export class PrismaTeamsRepository implements ITeamsRepository {

--- a/src/repositories/tournaments/InMemoryTournamentsRepository.ts
+++ b/src/repositories/tournaments/InMemoryTournamentsRepository.ts
@@ -1,16 +1,17 @@
 import { Prisma, Tournament } from '@prisma/client';
+
 import { ITournamentsRepository } from './ITournamentsRepository';
 
 export class InMemoryTournamentsRepository implements ITournamentsRepository {
   public tournaments: Tournament[] = [];
-  async findById(id: number): Promise<Tournament | null> {
+  findById(id: number): Promise<Tournament | null> {
     const tournament = this.tournaments.find((t) => t.id === id);
     if (!tournament) {
-      return null;
+      return Promise.resolve(null);
     }
-    return tournament;
+    return Promise.resolve(tournament);
   }
-  async create(data: Prisma.TournamentCreateInput): Promise<Tournament> {
+  create(data: Prisma.TournamentCreateInput): Promise<Tournament> {
     const newId = this.tournaments.length + 1;
     const tournament: Tournament = {
       id: newId,
@@ -22,10 +23,10 @@ export class InMemoryTournamentsRepository implements ITournamentsRepository {
       logoUrl: data.logoUrl ?? '',
     };
     this.tournaments.push(tournament);
-    return tournament;
+    return Promise.resolve(tournament);
   }
 
-  async list(): Promise<Tournament[]> {
-    return this.tournaments;
+  list(): Promise<Tournament[]> {
+    return Promise.resolve(this.tournaments);
   }
 }

--- a/src/repositories/tournaments/PrismaTournamentsRepository.ts
+++ b/src/repositories/tournaments/PrismaTournamentsRepository.ts
@@ -1,5 +1,7 @@
-import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
 import { ITournamentsRepository } from './ITournamentsRepository';
 
 export class PrismaTournamentsRepository implements ITournamentsRepository {

--- a/src/repositories/users/IUsersRepository.ts
+++ b/src/repositories/users/IUsersRepository.ts
@@ -1,13 +1,5 @@
 import { Prisma, User } from '@prisma/client';
 
-interface ICreateUserDTO {
-  username: string;
-  email: string;
-  passwordHash: string;
-  fullName: string;
-  profileImageUrl: string;
-}
-
 export interface IUsersRepository {
   findByEmail(email: string): Promise<User | null>;
   findById(id: string): Promise<User | null>;

--- a/src/repositories/users/PrismaUsersRepository.ts
+++ b/src/repositories/users/PrismaUsersRepository.ts
@@ -1,6 +1,7 @@
 import { Prisma, User } from '@prisma/client';
-import { prisma } from '../../lib/prisma';
+
 import { IUsersRepository } from './IUsersRepository';
+import { prisma } from '../../lib/prisma';
 
 export class PrismaUsersRepository implements IUsersRepository {
   async findByEmail(email: string) {

--- a/src/test/mocks/predictions.ts
+++ b/src/test/mocks/predictions.ts
@@ -1,5 +1,6 @@
-import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
 import { Prediction } from '@prisma/client';
+
+import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
 
 export async function createPrediction(
   repository: IPredictionsRepository,
@@ -16,8 +17,6 @@ export async function createPrediction(
   }
 ): Promise<Prediction> {
   const randomPredictionNumber = Math.floor(Math.random() * 100);
-  const homeRandomNumber = Math.floor(Math.random() * 10);
-  const awayRandomNumber = Math.floor(Math.random() * 10);
 
   const prediction = await repository.create({
     match: {

--- a/src/test/mocks/teams.ts
+++ b/src/test/mocks/teams.ts
@@ -1,6 +1,7 @@
-import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
 import { fakerPT_BR as faker } from '@faker-js/faker';
 import { Team } from '@prisma/client';
+
+import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
 
 export async function createTeam(
   repository: ITeamsRepository,

--- a/src/test/mocks/tournament.ts
+++ b/src/test/mocks/tournament.ts
@@ -1,6 +1,7 @@
-import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { fakerPT_BR as faker } from '@faker-js/faker';
 import { Tournament, TournamentStatus } from '@prisma/client';
+
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 
 export async function createTournament(
   repository: ITournamentsRepository,

--- a/src/test/mocks/users.ts
+++ b/src/test/mocks/users.ts
@@ -1,6 +1,7 @@
-import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { fakerPT_BR as faker } from '@faker-js/faker';
 import { AccountProvider, AccountRole, User } from '@prisma/client';
+
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 
 export async function createUser(
   repository: IUsersRepository,

--- a/src/useCases/matches/factories/makeGetMatchPredictionsUseCase.ts
+++ b/src/useCases/matches/factories/makeGetMatchPredictionsUseCase.ts
@@ -1,5 +1,6 @@
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
 import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
+
 import { GetMatchPredictionsUseCase } from '../getMatchPredictionsUseCase';
 
 export function makeGetMatchPredictionsUseCase() {

--- a/src/useCases/matches/factories/makeGetMatchUseCase.ts
+++ b/src/useCases/matches/factories/makeGetMatchUseCase.ts
@@ -1,4 +1,5 @@
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
+
 import { GetMatchUseCase } from '../getMatchUseCase';
 
 export function makeGetMatchUseCase() {

--- a/src/useCases/matches/factories/makeUpdateMatchUseCase.ts
+++ b/src/useCases/matches/factories/makeUpdateMatchUseCase.ts
@@ -1,5 +1,6 @@
 import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+
 import { UpdateMatchUseCase } from '../updateMatchUseCase';
 
 export function makeUpdateMatchUseCase() {

--- a/src/useCases/matches/getMatchPredictionsUseCase.spec.ts
+++ b/src/useCases/matches/getMatchPredictionsUseCase.spec.ts
@@ -1,3 +1,6 @@
+import { Match, Pool, User } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
 import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
@@ -7,8 +10,7 @@ import { createMatch, createMatchWithTeams } from '@/test/mocks/match';
 import { createPool } from '@/test/mocks/pools';
 import { createTeam } from '@/test/mocks/teams';
 import { createUser } from '@/test/mocks/users';
-import { Match, Pool, User } from '@prisma/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { GetMatchPredictionsUseCase } from './getMatchPredictionsUseCase';
 
 describe('Get Match Predictions Use Case', () => {

--- a/src/useCases/matches/getMatchPredictionsUseCase.ts
+++ b/src/useCases/matches/getMatchPredictionsUseCase.ts
@@ -1,7 +1,8 @@
+import { Prediction } from '@prisma/client';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
 import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
-import { Prediction } from '@prisma/client';
 
 interface GetMatchPredictionsRequest {
   matchId: number;

--- a/src/useCases/matches/getMatchUseCase.spec.ts
+++ b/src/useCases/matches/getMatchUseCase.spec.ts
@@ -1,3 +1,6 @@
+import { Match, MatchStage, MatchStatus, Team, Tournament } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
 import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
@@ -5,8 +8,7 @@ import { InMemoryTournamentsRepository } from '@/repositories/tournaments/InMemo
 import { createMatch } from '@/test/mocks/match';
 import { createTeam } from '@/test/mocks/teams';
 import { createTournament } from '@/test/mocks/tournament';
-import { Match, MatchStage, MatchStatus, Team, Tournament } from '@prisma/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { GetMatchUseCase } from './getMatchUseCase';
 
 // Define an extended Match type that includes the related entities

--- a/src/useCases/matches/getMatchUseCase.ts
+++ b/src/useCases/matches/getMatchUseCase.ts
@@ -1,6 +1,7 @@
+import { Match } from '@prisma/client';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
-import { Match } from '@prisma/client';
 
 interface GetMatchRequest {
   matchId: number;

--- a/src/useCases/pools/createPoolUseCase.spec.ts
+++ b/src/useCases/pools/createPoolUseCase.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { InviteCodeInUseError } from '@/global/errors/InviteCodeInUseError';
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
@@ -6,7 +8,7 @@ import { InMemoryTournamentsRepository } from '@/repositories/tournaments/InMemo
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { CreatePoolUseCase } from './createPoolUseCase';
 
 let poolsRepository: IPoolsRepository;

--- a/src/useCases/pools/createPoolUseCase.ts
+++ b/src/useCases/pools/createPoolUseCase.ts
@@ -2,6 +2,7 @@ import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+
 import { InviteCodeRequiredError } from './errors/InviteCodeRequiredError';
 import { PoolNameInUseError } from './errors/PoolNameInUseError';
 

--- a/src/useCases/pools/factory/makeCreatePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeCreatePoolUseCase.ts
@@ -1,6 +1,7 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { CreatePoolUseCase } from '../createPoolUseCase';
 
 export function makeCreatePoolUseCase() {

--- a/src/useCases/pools/factory/makeGetPoolPredictionsUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolPredictionsUseCase.ts
@@ -1,6 +1,7 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { GetPoolPredictionsUseCase } from '../getPoolsPredictionsUseCase';
 
 export function makeGetPoolPredictionsUseCase() {

--- a/src/useCases/pools/factory/makeGetPoolStandingsUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolStandingsUseCase.ts
@@ -1,5 +1,6 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { GetPoolStandingsUseCase } from '../getPoolStandingsUseCase';
 
 export function makeGetPoolStandingsUseCase() {

--- a/src/useCases/pools/factory/makeGetPoolUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolUseCase.ts
@@ -2,6 +2,7 @@ import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepositor
 import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { GetPoolUseCase } from '../getPoolUseCase';
 
 export function makeGetPoolUseCase() {

--- a/src/useCases/pools/factory/makeGetPoolUsersUseCase.ts
+++ b/src/useCases/pools/factory/makeGetPoolUsersUseCase.ts
@@ -1,6 +1,7 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { GetPoolUsersUseCase } from '../getPoolUsersUseCase';
 
 export function makeGetPoolUsersUseCase() {

--- a/src/useCases/pools/factory/makeGetUserPoolsUseCase.ts
+++ b/src/useCases/pools/factory/makeGetUserPoolsUseCase.ts
@@ -1,5 +1,6 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { GetUserPoolsUseCase } from '../getUserPoolsUseCase';
 
 export function makeGetUserPoolsUseCase() {

--- a/src/useCases/pools/factory/makeLeavePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeLeavePoolUseCase.ts
@@ -1,6 +1,7 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { LeavePoolUseCase } from '../leavePoolUseCase';
 
 export function makeLeavePoolUseCase() {

--- a/src/useCases/pools/factory/makeRemoveUserFromPoolUseCase.ts
+++ b/src/useCases/pools/factory/makeRemoveUserFromPoolUseCase.ts
@@ -1,5 +1,6 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { RemoveUserFromPoolUseCase } from '../removeUserFromPoolUseCase';
 
 export function makeRemoveUserFromPoolUseCase() {

--- a/src/useCases/pools/factory/makeUpdatePoolUseCase.ts
+++ b/src/useCases/pools/factory/makeUpdatePoolUseCase.ts
@@ -1,6 +1,7 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { UpdatePoolUseCase } from '../updatePoolUseCase';
 
 export function makeUpdatePoolUseCase() {

--- a/src/useCases/pools/getPoolPredictionsUseCase.spec.ts
+++ b/src/useCases/pools/getPoolPredictionsUseCase.spec.ts
@@ -1,3 +1,6 @@
+import { Pool, Prediction, Tournament, User } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
@@ -11,8 +14,7 @@ import { createPool, createPoolWithParticipants } from '@/test/mocks/pools';
 import { createPrediction } from '@/test/mocks/predictions';
 import { createTournament } from '@/test/mocks/tournament';
 import { createUser } from '@/test/mocks/users';
-import { Pool, Prediction, Tournament, User } from '@prisma/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { NotParticipantError } from './errors/NotParticipantError';
 import { GetPoolPredictionsUseCase } from './getPoolsPredictionsUseCase';
 

--- a/src/useCases/pools/getPoolStandingsUseCase.spec.ts
+++ b/src/useCases/pools/getPoolStandingsUseCase.spec.ts
@@ -1,3 +1,6 @@
+import { Match, MatchStage, MatchStatus, Pool, User } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
@@ -10,8 +13,7 @@ import { createPool } from '@/test/mocks/pools';
 import { createPrediction } from '@/test/mocks/predictions';
 import { createTeam } from '@/test/mocks/teams';
 import { createUser } from '@/test/mocks/users';
-import { Match, MatchStage, MatchStatus, Pool, User } from '@prisma/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { GetPoolStandingsUseCase } from './getPoolStandingsUseCase';
 
 describe('GetPoolStandingsUseCase', () => {
@@ -26,7 +28,7 @@ describe('GetPoolStandingsUseCase', () => {
   let creator: User;
   let regularUser: User;
   let pool: Pool;
-  let matches: Match[] = [];
+  const matches: Match[] = [];
 
   beforeEach(async () => {
     poolsRepository = new InMemoryPoolsRepository();

--- a/src/useCases/pools/getPoolUseCase.spec.ts
+++ b/src/useCases/pools/getPoolUseCase.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
@@ -6,7 +8,7 @@ import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsR
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { GetPoolUseCase } from './getPoolUseCase';
 
 let poolsRepository: IPoolsRepository;
@@ -81,7 +83,7 @@ describe('Get Pool Use Case', () => {
     });
 
     // Create scoring rules for the pool
-    const scoringRules = await poolsRepository.createScoringRules({
+    await poolsRepository.createScoringRules({
       pool: { connect: { id: pool.id } },
       exactScorePoints: 3,
       correctWinnerGoalDiffPoints: 2,
@@ -103,10 +105,8 @@ describe('Get Pool Use Case', () => {
     expect(result.id).toBe(pool.id);
     expect(result.name).toBe('Test Pool');
     expect(result.scoringRules).toBeDefined();
-    expect(result.scoringRules!.exactScorePoints).toBe(scoringRules.exactScorePoints);
-    expect(result.scoringRules!.correctWinnerGoalDiffPoints).toBe(
-      scoringRules.correctWinnerGoalDiffPoints
-    );
+    expect(result.scoringRules.exactScorePoints).toBe(3);
+    expect(result.scoringRules.correctWinnerGoalDiffPoints).toBe(2);
     expect(result.participants).toHaveLength(3);
   });
 
@@ -197,7 +197,7 @@ describe('Get Pool Use Case', () => {
     });
 
     // Create scoring rules
-    const scoringRules = await poolsRepository.createScoringRules({
+    await poolsRepository.createScoringRules({
       pool: { connect: { id: pool.id } },
       exactScorePoints: 3,
       correctWinnerGoalDiffPoints: 2,

--- a/src/useCases/pools/getPoolUsersUseCase.spec.ts
+++ b/src/useCases/pools/getPoolUsersUseCase.spec.ts
@@ -1,10 +1,12 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { NotParticipantError } from './errors/NotParticipantError';
 import { GetPoolUsersUseCase } from './getPoolUsersUseCase';
 

--- a/src/useCases/pools/getPoolsPredictionsUseCase.ts
+++ b/src/useCases/pools/getPoolsPredictionsUseCase.ts
@@ -1,8 +1,9 @@
+import { Prediction } from '@prisma/client';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
-import { Prediction } from '@prisma/client';
 
 interface GetPoolPredictionsUseCaseRequest {
   poolId: number;

--- a/src/useCases/pools/getUserPoolsUseCase.spec.ts
+++ b/src/useCases/pools/getUserPoolsUseCase.spec.ts
@@ -1,7 +1,9 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { GetUserPoolsUseCase } from './getUserPoolsUseCase';
 
 let poolsRepository: InMemoryPoolsRepository;
@@ -84,7 +86,7 @@ describe('Get User Pools Use Case', () => {
       passwordHash: 'passwordHash123',
     });
 
-    const otherUser = await usersRepository.create({
+    await usersRepository.create({
       email: 'jane@example.com',
       fullName: 'Jane Doe',
       passwordHash: 'passwordHash123',
@@ -121,7 +123,7 @@ describe('Get User Pools Use Case', () => {
       passwordHash: 'passwordHash123',
     });
 
-    const otherUser = await usersRepository.create({
+    await usersRepository.create({
       email: 'jane@example.com',
       fullName: 'Jane Doe',
       passwordHash: 'passwordHash123',

--- a/src/useCases/pools/leavePoolUseCase.spec.ts
+++ b/src/useCases/pools/leavePoolUseCase.spec.ts
@@ -1,10 +1,12 @@
-import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
+import { LeavePoolUseCase } from './leavePoolUseCase';
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '../../repositories/pools/InMemoryPoolsRepository';
 import { InMemoryTournamentsRepository } from '../../repositories/tournaments/InMemoryTournamentsRepository';
 import { InMemoryUsersRepository } from '../../repositories/users/InMemoryUsersRepository';
-import { LeavePoolUseCase } from './leavePoolUseCase';
 
 let poolsRepository: InMemoryPoolsRepository;
 let usersRepository: InMemoryUsersRepository;

--- a/src/useCases/pools/leavePoolUseCase.ts
+++ b/src/useCases/pools/leavePoolUseCase.ts
@@ -1,4 +1,5 @@
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
 import { IUsersRepository } from '../../repositories/users/IUsersRepository';

--- a/src/useCases/pools/updatePoolUseCase.spec.ts
+++ b/src/useCases/pools/updatePoolUseCase.spec.ts
@@ -1,10 +1,12 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
 import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { NotPoolCreatorError } from './errors/NotPoolCreatorError';
 import { UpdatePoolUseCase } from './updatePoolUseCase';
 

--- a/src/useCases/pools/updatePoolUseCase.ts
+++ b/src/useCases/pools/updatePoolUseCase.ts
@@ -1,4 +1,5 @@
 import { PoolAuthorizationService } from '@/services/pools/PoolAuthorizationService';
+
 import { ResourceNotFoundError } from '../../global/errors/ResourceNotFoundError';
 import { IPoolsRepository } from '../../repositories/pools/IPoolsRepository';
 import { IUsersRepository } from '../../repositories/users/IUsersRepository';
@@ -40,7 +41,7 @@ export class UpdatePoolUseCase {
     }
 
     // Validate user is the pool creator
-    await this.poolAuthorizationService.validatePoolCreatorAccess(poolId, userId, pool.creatorId);
+    this.poolAuthorizationService.validatePoolCreatorAccess(poolId, userId, pool.creatorId);
 
     const updatedPool = await this.poolsRepository.update(poolId, {
       name,

--- a/src/useCases/predictions/factories/makeCreatePredictionUseCase.ts
+++ b/src/useCases/predictions/factories/makeCreatePredictionUseCase.ts
@@ -2,6 +2,7 @@ import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRep
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { CreatePredictionUseCase } from '../createPredictionUseCase';
 
 export function makeCreatePredictionUseCase() {

--- a/src/useCases/predictions/factories/makeGetPredictionUseCase.ts
+++ b/src/useCases/predictions/factories/makeGetPredictionUseCase.ts
@@ -1,4 +1,5 @@
 import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
+
 import { GetPredictionUseCase } from '../getPredictionUseCase';
 
 export function makeGetPredictionUseCase() {

--- a/src/useCases/predictions/factories/makeUpdatePredictionUseCase.ts
+++ b/src/useCases/predictions/factories/makeUpdatePredictionUseCase.ts
@@ -2,6 +2,7 @@ import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRep
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { UpdatePredictionUseCase } from '../updatePredictionUseCase';
 
 export function makeUpdatePredictionUseCase() {

--- a/src/useCases/predictions/getPredictionUseCase.spec.ts
+++ b/src/useCases/predictions/getPredictionUseCase.spec.ts
@@ -1,8 +1,10 @@
+import { Prediction } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
 import { createPrediction } from '@/test/mocks/predictions';
-import { Prediction } from '@prisma/client';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { NotParticipantError } from './error/NotParticipantError';
 import { GetPredictionUseCase } from './getPredictionUseCase';
 

--- a/src/useCases/predictions/getPredictionUseCase.ts
+++ b/src/useCases/predictions/getPredictionUseCase.ts
@@ -1,6 +1,8 @@
+import { Prediction } from '@prisma/client';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
-import { Prediction } from '@prisma/client';
+
 import { NotParticipantError } from './error/NotParticipantError';
 
 interface GetPredictionUseCaseRequest {

--- a/src/useCases/predictions/updatePredictionUseCase.spec.ts
+++ b/src/useCases/predictions/updatePredictionUseCase.spec.ts
@@ -105,7 +105,7 @@ describe('Update Prediction Use Case', () => {
   });
 
   it('should not allow updating a prediction for a match that has already started', async () => {
-    const { match, homeTeam, awayTeam } = await createMatchWithTeams(
+    const { match } = await createMatchWithTeams(
       { matchesRepository, teamsRepository },
       {
         tournamentId: aPool.tournamentId,
@@ -158,7 +158,7 @@ describe('Update Prediction Use Case', () => {
   });
 
   it('should update a prediction with extra time and penalties for knockout stage matches', async () => {
-    const { match, homeTeam, awayTeam } = await createMatchWithTeams(
+    const { match } = await createMatchWithTeams(
       { matchesRepository, teamsRepository },
       {
         tournamentId: aPool.tournamentId,
@@ -196,7 +196,7 @@ describe('Update Prediction Use Case', () => {
   });
 
   it('should not allow updating a prediction with penalties if scores are not tied', async () => {
-    const { match, homeTeam, awayTeam } = await createMatchWithTeams(
+    const { match } = await createMatchWithTeams(
       { matchesRepository, teamsRepository },
       {
         tournamentId: aPool.tournamentId,
@@ -229,7 +229,7 @@ describe('Update Prediction Use Case', () => {
   });
 
   it('should validate that penalty scores must be provided when hasPenalties is true during update', async () => {
-    const { match, homeTeam, awayTeam } = await createMatchWithTeams(
+    const { match } = await createMatchWithTeams(
       { matchesRepository, teamsRepository },
       {
         tournamentId: aPool.tournamentId,
@@ -262,7 +262,7 @@ describe('Update Prediction Use Case', () => {
   });
 
   it('should validate that extra time and penalties can only be true if scores are tied during update', async () => {
-    const { match, homeTeam, awayTeam } = await createMatchWithTeams(
+    const { match } = await createMatchWithTeams(
       { matchesRepository, teamsRepository },
       {
         tournamentId: aPool.tournamentId,

--- a/src/useCases/teams/createTeamUseCase.spec.ts
+++ b/src/useCases/teams/createTeamUseCase.spec.ts
@@ -1,5 +1,7 @@
-import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import { InMemoryTeamsRepository } from '@/repositories/teams/InMemoryTeamsRepository';
+
 import { CreateTeamUseCase } from './createTeamUseCase';
 
 let teamsRepository: InMemoryTeamsRepository;

--- a/src/useCases/teams/createTeamUseCase.ts
+++ b/src/useCases/teams/createTeamUseCase.ts
@@ -1,5 +1,6 @@
-import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
 import { Team } from '@prisma/client';
+
+import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
 
 interface ICreateTeamRequest {
   name: string;

--- a/src/useCases/tournaments/listTournamentsUseCase.spec.ts
+++ b/src/useCases/tournaments/listTournamentsUseCase.spec.ts
@@ -1,6 +1,8 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { InMemoryTournamentsRepository } from '@/repositories/tournaments/InMemoryTournamentsRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ListTournamentsUseCase } from './listTournamentsUseCase';
 
 let tournamentsRepository: ITournamentsRepository;

--- a/src/useCases/tournaments/listTournamentsUseCase.ts
+++ b/src/useCases/tournaments/listTournamentsUseCase.ts
@@ -1,5 +1,6 @@
-import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 import { Tournament } from '@prisma/client';
+
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 
 interface ListTournamentsUseCaseResponse {
   tournaments: Tournament[];

--- a/src/useCases/users/createUserUseCase.spec.ts
+++ b/src/useCases/users/createUserUseCase.spec.ts
@@ -1,7 +1,9 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { EmailInUseError } from '@/global/errors/EmailInUseError';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { IUsersRepository } from '@/repositories/users/IUsersRepository';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { CreateUserUseCase } from './createUserUseCase';
 
 let usersRepository: IUsersRepository;

--- a/src/useCases/users/factory/makeGetUserPoolStandingUseCase.ts
+++ b/src/useCases/users/factory/makeGetUserPoolStandingUseCase.ts
@@ -1,5 +1,6 @@
 import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { GetUserPoolStandingUseCase } from '../getUserPoolsStandingsUseCase';
 
 export function makeGetUserPoolStandingUseCase() {

--- a/src/useCases/users/factory/makeUpdateUserUseCase.ts
+++ b/src/useCases/users/factory/makeUpdateUserUseCase.ts
@@ -1,4 +1,5 @@
 import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+
 import { UpdateUserUseCase } from '../updateUserUseCase';
 
 export function makeUpdateUserUseCase() {

--- a/src/useCases/users/getUserInfoUseCase.spec.ts
+++ b/src/useCases/users/getUserInfoUseCase.spec.ts
@@ -1,6 +1,8 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
 import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
-import { beforeEach, describe, expect, it } from 'vitest';
+
 import { GetUserInfoUseCase } from './getUserInfoUseCase';
 
 describe('Get User Info Use Case', () => {

--- a/src/useCases/users/updateUserUseCase.spec.ts
+++ b/src/useCases/users/updateUserUseCase.spec.ts
@@ -1,7 +1,9 @@
-import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
-import { IUsersRepository } from '@/repositories/users/IUsersRepository';
-import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryUsersRepository } from '@/repositories/users/InMemoryUsersRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+
 import { UpdateUserUseCase } from './updateUserUseCase';
 
 let usersRepository: IUsersRepository;


### PR DESCRIPTION
- Reordered and grouped import statements for better readability in:
  - PrismaUsersRepository
  - predictions mocks
  - teams mocks
  - tournament mocks
  - users mocks
  - various use case factories
  - getMatchPredictionsUseCase
  - getMatchUseCase
  - createPoolUseCase
  - leavePoolUseCase
  - updatePoolUseCase
  - getPoolPredictionsUseCase
  - getUserPoolsUseCase
  - updatePredictionUseCase
  - createTeamUseCase
  - listTournamentsUseCase
  - createUserUseCase
  - getUserInfoUseCase
  - updateUserUseCase

- Removed unnecessary variable declarations and improved code clarity in:
  - getMatchPredictionsUseCase.spec.ts
  - getMatchUseCase.spec.ts
  - leavePoolUseCase.spec.ts
  - updatePredictionUseCase.spec.ts
  - various other test files

- Ensured consistent import styles and formatting throughout the codebase.