### PR TITLE
chore: align runtime entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ COPY package*.json ./
 RUN npm ci             # install dev + prod deps
 
 COPY . .
-RUN npm run build      # generates build/server.js
+RUN npm run build      # generates build/server.cjs
 RUN npx prisma generate  # generates prisma client
 RUN npm prune --production  # optional: keep only prod deps
 
-CMD ["node", "build/server.cjs"]
+CMD ["node", "./build/server.cjs"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "start": "node build/server.js",
+    "start": "node build/server.cjs",
     "build": "tsup src --out-dir build",
     "test": "vitest",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- point the package start script at the compiled server.cjs output
- document the server.cjs build artifact in the Dockerfile and run it from the same path

## Testing
- npm start
- docker build . *(fails: docker command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd25e82ec8328b0e5a4792977734f