### PR TITLE
chore: remove unused supabase service role key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ LOG_LEVEL=info
 # Supabase
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=
 
 # Database
 DATABASE_URL=postgresql://docker:docker@localhost:5432/bolao

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,3 @@ jobs:
           HOST: 0.0.0.0
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/src/env/config.ts
+++ b/src/env/config.ts
@@ -19,7 +19,6 @@ const envSchema = z.object({
   DATABASE_URL: z.string(),
   SUPABASE_URL: z.string(),
   SUPABASE_ANON_KEY: z.string(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string(),
   TEST_USER_PASSWORD: z.string().optional(),
   TEST_USER_EMAIL: z.string().optional(),
 }).superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary
- remove the Supabase service role key from the runtime env schema and sample config
- stop passing the unused Supabase secret to the CI workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd18cced808328839506577ded3f3d