### PR TITLE
Use startup script for container entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci             # install dev + prod deps
 
+COPY scripts/start.sh ./scripts/start.sh
 COPY . .
+RUN chmod +x scripts/start.sh
 RUN npm run build      # generates build/server.cjs
 RUN npx prisma generate  # generates prisma client
 RUN npm prune --production  # optional: keep only prod deps
 
-CMD ["node", "./build/server.cjs"]
+CMD ["./scripts/start.sh"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 See `AGENTS.md` for commands and project guidelines.
 
+## Production Startup
+
+- `scripts/start.sh` applies pending migrations with `npx prisma migrate deploy` and then boots the compiled server.
+- The script intentionally skips `npx prisma db seed` so production data is never reset during container start.
+
 ## Database Seeding
 
 - Entry point: `prisma/seed.ts` orchestrates seeding order.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
+cd "$PROJECT_ROOT"
+
+printf '%s\n' 'Applying Prisma migrations...'
+npx prisma migrate deploy
+
+SERVER_ENTRY=""
+if [ -f "build/server.cjs" ]; then
+  SERVER_ENTRY="build/server.cjs"
+elif [ -f "build/server.js" ]; then
+  SERVER_ENTRY="build/server.js"
+else
+  printf '%s\n' 'Error: expected build/server.cjs or build/server.js to exist after build step.' >&2
+  exit 1
+fi
+
+printf 'Starting application with %s\n' "$SERVER_ENTRY"
+exec node "$SERVER_ENTRY"


### PR DESCRIPTION
## Summary
- add a startup script that runs `npx prisma migrate deploy` and then starts the compiled server
- copy the script into the image and switch the Docker CMD to execute it
- document that the startup script intentionally avoids running `prisma db seed`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd1c5a01808328b861e62a15bdae14