### PR TITLE
fix: align swagger transform signature

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import cors from '@fastify/cors';
 import fastifyJwt from '@fastify/jwt';
 import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
-import fastify, { FastifyInstance } from 'fastify';
+import fastify, { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { ZodError } from 'zod';
 
 import { env } from './env/config';
@@ -111,12 +111,10 @@ export const createServer = async (): Promise<FastifyInstance> => {
         },
       },
       transformSpecification: (
-        swaggerObject: unknown,
-        _request: unknown,
-        _reply: unknown
-      ): unknown => {
-        return swaggerObject;
-      },
+        swaggerObject: Readonly<Record<string, any>>,
+        _request: FastifyRequest,
+        _reply: FastifyReply
+      ): Record<string, any> => swaggerObject,
       transformSpecificationClone: true,
     });
   }


### PR DESCRIPTION
## Summary
- import the Fastify request and reply types alongside the existing instance type
- update the Swagger UI transform specification callback to use Fastify's request/reply signature while returning the original document

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d10a24034c83288534c90d51daf908