### PR TITLE
fix: type swagger schema maps

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import fastifyJwt from '@fastify/jwt';
 import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
 import fastify, { FastifyInstance } from 'fastify';
+import type { OpenAPIV3 } from 'openapi-types';
 import { ZodError } from 'zod';
 
 import { env } from './env/config';
@@ -43,9 +44,9 @@ export const createServer = async (): Promise<FastifyInstance> => {
   const { tournamentSchemas } = await import('./http/schemas/tournament.schemas');
 
   // Combine all schemas and remove duplicates
-  const allSchemas: Record<string, unknown> = {};
+  const allSchemas: Record<string, OpenAPIV3.SchemaObject> = {};
 
-  const mergeSchemas = (schemas: Record<string, unknown>) => {
+  const mergeSchemas = (schemas: Record<string, OpenAPIV3.SchemaObject>) => {
     Object.entries(schemas).forEach(([key, schema]) => {
       if (allSchemas[key]) {
         server.log.warn(`Duplicate schema detected for ${key}, keeping existing definition.`);

--- a/src/http/schemas/common.schemas.ts
+++ b/src/http/schemas/common.schemas.ts
@@ -1,4 +1,6 @@
-export const commonSchemas = {
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const commonSchemas: Record<string, OpenAPIV3.SchemaObject> = {
   UnauthorizedError: {
     type: 'object',
     properties: {

--- a/src/http/schemas/match.schemas.ts
+++ b/src/http/schemas/match.schemas.ts
@@ -1,4 +1,6 @@
-export const matchSchemas = {
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const matchSchemas: Record<string, OpenAPIV3.SchemaObject> = {
   // Base Match schema
   Match: {
     type: 'object',

--- a/src/http/schemas/pool.schemas.ts
+++ b/src/http/schemas/pool.schemas.ts
@@ -1,4 +1,6 @@
-export const poolSchemas = {
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const poolSchemas: Record<string, OpenAPIV3.SchemaObject> = {
   // Base Pool object
   Pool: {
     type: 'object',

--- a/src/http/schemas/prediction.schemas.ts
+++ b/src/http/schemas/prediction.schemas.ts
@@ -1,4 +1,6 @@
-export const predictionSchemas = {
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const predictionSchemas: Record<string, OpenAPIV3.SchemaObject> = {
   // Base Prediction schema
   Prediction: {
     type: 'object',

--- a/src/http/schemas/tournament.schemas.ts
+++ b/src/http/schemas/tournament.schemas.ts
@@ -1,4 +1,6 @@
-export const tournamentSchemas = {
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const tournamentSchemas: Record<string, OpenAPIV3.SchemaObject> = {
   // Base Tournament schema
   Tournament: {
     type: 'object',

--- a/src/http/schemas/user.schemas.ts
+++ b/src/http/schemas/user.schemas.ts
@@ -1,4 +1,6 @@
-export const userSchemas = {
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const userSchemas: Record<string, OpenAPIV3.SchemaObject> = {
   // Base User object
   User: {
     type: 'object',


### PR DESCRIPTION
## Summary
- use the OpenAPIV3 schema type when collecting swagger components during app bootstrap
- annotate each schema map export under src/http/schemas to satisfy the OpenAPI schema shape

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10e746e008328b9d02cee1cb3b01e