### PR TITLE
feat: add GET /matches/:matchId/predictions/me endpoint

### DIFF
--- a/src/http/controllers/predictions/getMyMatchPredictionsController.spec.ts
+++ b/src/http/controllers/predictions/getMyMatchPredictionsController.spec.ts
@@ -1,0 +1,309 @@
+import { MatchStage, MatchStatus } from '@prisma/client';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
+import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
+import { IPoolsRepository } from '@/repositories/pools/IPoolsRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+import { IPredictionsRepository } from '@/repositories/predictions/IPredictionsRepository';
+import { PrismaPredictionsRepository } from '@/repositories/predictions/PrismaPredictionsRepository';
+import { ITeamsRepository } from '@/repositories/teams/ITeamsRepository';
+import { PrismaTeamsRepository } from '@/repositories/teams/PrismaTeamsRepository';
+import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
+import { PrismaTournamentsRepository } from '@/repositories/tournaments/PrismaTournamentsRepository';
+import { IUsersRepository } from '@/repositories/users/IUsersRepository';
+import { PrismaUsersRepository } from '@/repositories/users/PrismaUsersRepository';
+import { createTestApp } from '@/test/helper-e2e';
+import { getSupabaseAccessToken } from '@/test/mockJwt';
+import { createMatch } from '@/test/mocks/match';
+import { createPool } from '@/test/mocks/pools';
+import { createPrediction } from '@/test/mocks/predictions';
+import { createTeam } from '@/test/mocks/teams';
+import { createTournament } from '@/test/mocks/tournament';
+import { createUser } from '@/test/mocks/users';
+
+type PredictionEntry = {
+  poolId: number;
+  poolName: string;
+  matchId: number;
+  prediction: {
+    id: number;
+    predictedHomeScore: number;
+    predictedAwayScore: number;
+    predictedHasExtraTime: boolean;
+    predictedHasPenalties: boolean;
+    predictedPenaltyHomeScore: number | null;
+    predictedPenaltyAwayScore: number | null;
+    pointsEarned: number | null;
+    submittedAt: string;
+    updatedAt: string | null;
+  } | null;
+};
+
+type GetMyMatchPredictionsResponse = {
+  predictions: PredictionEntry[];
+};
+
+type ErrorResponse = {
+  message: string;
+};
+
+describe('Get My Match Predictions Controller (e2e)', async () => {
+  const app = await createTestApp();
+  let userId: string;
+  let token: string;
+  let tournamentId: number;
+
+  let usersRepository: IUsersRepository;
+  let poolsRepository: IPoolsRepository;
+  let tournamentsRepository: ITournamentsRepository;
+  let matchesRepository: IMatchesRepository;
+  let teamsRepository: ITeamsRepository;
+  let predictionsRepository: IPredictionsRepository;
+
+  beforeAll(async () => {
+    ({ token, userId } = await getSupabaseAccessToken(app));
+
+    usersRepository = new PrismaUsersRepository();
+    poolsRepository = new PrismaPoolsRepository();
+    tournamentsRepository = new PrismaTournamentsRepository();
+    matchesRepository = new PrismaMatchesRepository();
+    teamsRepository = new PrismaTeamsRepository();
+    predictionsRepository = new PrismaPredictionsRepository();
+
+    const tournament = await createTournament(tournamentsRepository, {});
+    tournamentId = tournament.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(app.server).get('/matches/1/predictions/me');
+
+    expect(response.statusCode).toEqual(401);
+  });
+
+  it('should return 404 when match does not exist', async () => {
+    const response = await request(app.server)
+      .get('/matches/999999/predictions/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(404);
+
+    const body = response.body as ErrorResponse;
+    expect(body.message).toContain('Match not found');
+  });
+
+  it('should return empty predictions array when user belongs to no pools for the tournament', async () => {
+    const homeTeam = await createTeam(teamsRepository, { name: 'Team A Empty' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Team B Empty' });
+    const match = await createMatch(
+      matchesRepository,
+      { tournamentId, matchStatus: MatchStatus.SCHEDULED, matchStage: MatchStage.GROUP },
+      homeTeam,
+      awayTeam
+    );
+
+    const response = await request(app.server)
+      .get(`/matches/${match.id}/predictions/me`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const body = response.body as GetMyMatchPredictionsResponse;
+    expect(body.predictions).toEqual([]);
+  });
+
+  it('should return one entry per pool with prediction: null when no prediction was submitted', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Team A NoPred' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Team B NoPred' });
+    const match = await createMatch(
+      matchesRepository,
+      { tournamentId: tournament.id, matchStatus: MatchStatus.SCHEDULED, matchStage: MatchStage.GROUP },
+      homeTeam,
+      awayTeam
+    );
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      name: 'Pool No Prediction',
+    });
+
+    const response = await request(app.server)
+      .get(`/matches/${match.id}/predictions/me`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const body = response.body as GetMyMatchPredictionsResponse;
+    expect(body.predictions).toHaveLength(1);
+    expect(body.predictions[0].poolId).toBe(pool.id);
+    expect(body.predictions[0].poolName).toBe('Pool No Prediction');
+    expect(body.predictions[0].matchId).toBe(match.id);
+    expect(body.predictions[0].prediction).toBeNull();
+  });
+
+  it('should return the prediction when one was submitted', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Team A WithPred' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Team B WithPred' });
+    const match = await createMatch(
+      matchesRepository,
+      { tournamentId: tournament.id, matchStatus: MatchStatus.SCHEDULED, matchStage: MatchStage.GROUP },
+      homeTeam,
+      awayTeam
+    );
+
+    const pool = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      name: 'Pool With Prediction',
+    });
+
+    await createPrediction(predictionsRepository, {
+      userId,
+      matchId: match.id,
+      poolId: pool.id,
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+
+    const response = await request(app.server)
+      .get(`/matches/${match.id}/predictions/me`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const body = response.body as GetMyMatchPredictionsResponse;
+    expect(body.predictions).toHaveLength(1);
+
+    const entry = body.predictions[0];
+    expect(entry.poolId).toBe(pool.id);
+    expect(entry.matchId).toBe(match.id);
+    expect(entry.prediction).not.toBeNull();
+    expect(entry.prediction?.predictedHomeScore).toBe(2);
+    expect(entry.prediction?.predictedAwayScore).toBe(1);
+    expect(entry.prediction?.predictedHasExtraTime).toBe(false);
+    expect(entry.prediction?.predictedHasPenalties).toBe(false);
+    expect(entry.prediction?.pointsEarned).toBeNull();
+    expect(entry.prediction?.submittedAt).toBeDefined();
+  });
+
+  it('should return one entry per pool mixing predictions and nulls', async () => {
+    const tournament = await createTournament(tournamentsRepository, {});
+    const homeTeam = await createTeam(teamsRepository, { name: 'Team A Mix' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Team B Mix' });
+    const match = await createMatch(
+      matchesRepository,
+      { tournamentId: tournament.id, matchStatus: MatchStatus.SCHEDULED, matchStage: MatchStage.GROUP },
+      homeTeam,
+      awayTeam
+    );
+
+    const poolWithPrediction = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      name: 'Pool Mix A',
+    });
+
+    const poolWithoutPrediction = await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: tournament.id,
+      name: 'Pool Mix B',
+    });
+
+    await createPrediction(predictionsRepository, {
+      userId,
+      matchId: match.id,
+      poolId: poolWithPrediction.id,
+      predictedHomeScore: 3,
+      predictedAwayScore: 0,
+    });
+
+    const response = await request(app.server)
+      .get(`/matches/${match.id}/predictions/me`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const body = response.body as GetMyMatchPredictionsResponse;
+    expect(body.predictions).toHaveLength(2);
+
+    const entryA = body.predictions.find((p) => p.poolId === poolWithPrediction.id);
+    const entryB = body.predictions.find((p) => p.poolId === poolWithoutPrediction.id);
+
+    expect(entryA?.prediction).not.toBeNull();
+    expect(entryA?.prediction?.predictedHomeScore).toBe(3);
+    expect(entryB?.prediction).toBeNull();
+  });
+
+  it('should not include pools from a different tournament', async () => {
+    const otherTournament = await createTournament(tournamentsRepository, {});
+
+    const homeTeam = await createTeam(teamsRepository, { name: 'Team A OtherTournament' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Team B OtherTournament' });
+    const match = await createMatch(
+      matchesRepository,
+      { tournamentId, matchStatus: MatchStatus.SCHEDULED, matchStage: MatchStage.GROUP },
+      homeTeam,
+      awayTeam
+    );
+
+    // Pool belongs to a different tournament
+    await createPool(poolsRepository, {
+      creatorId: userId,
+      tournamentId: otherTournament.id,
+      name: 'Pool Other Tournament',
+    });
+
+    const response = await request(app.server)
+      .get(`/matches/${match.id}/predictions/me`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const body = response.body as GetMyMatchPredictionsResponse;
+    // The pool from a different tournament should not appear
+    const hasOtherTournamentPool = body.predictions.some(
+      (p) => p.poolName === 'Pool Other Tournament'
+    );
+    expect(hasOtherTournamentPool).toBe(false);
+  });
+
+  it('should not include pools where the user is not a participant', async () => {
+    const otherUser = await createUser(usersRepository, {
+      email: 'other-user-mypreds@example.com',
+    });
+
+    const homeTeam = await createTeam(teamsRepository, { name: 'Team A NotPart' });
+    const awayTeam = await createTeam(teamsRepository, { name: 'Team B NotPart' });
+    const match = await createMatch(
+      matchesRepository,
+      { tournamentId, matchStatus: MatchStatus.SCHEDULED, matchStage: MatchStage.GROUP },
+      homeTeam,
+      awayTeam
+    );
+
+    // Pool created by another user; authenticated user is not a participant
+    await createPool(poolsRepository, {
+      creatorId: otherUser.id,
+      tournamentId,
+      name: 'Pool Not Participant',
+    });
+
+    const response = await request(app.server)
+      .get(`/matches/${match.id}/predictions/me`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.statusCode).toEqual(200);
+
+    const body = response.body as GetMyMatchPredictionsResponse;
+    const hasOtherPool = body.predictions.some((p) => p.poolName === 'Pool Not Participant');
+    expect(hasOtherPool).toBe(false);
+  });
+});

--- a/src/http/controllers/predictions/getMyMatchPredictionsController.ts
+++ b/src/http/controllers/predictions/getMyMatchPredictionsController.ts
@@ -1,0 +1,36 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { makeGetMyMatchPredictionsUseCase } from '@/useCases/predictions/factories/makeGetMyMatchPredictionsUseCase';
+
+const paramsSchema = z.object({
+  matchId: z.coerce.number(),
+});
+
+type Params = z.infer<typeof paramsSchema>;
+
+export async function getMyMatchPredictionsController(
+  request: FastifyRequest<{ Params: Params }>,
+  reply: FastifyReply
+): Promise<FastifyReply> {
+  try {
+    const { matchId } = paramsSchema.parse(request.params);
+    const userId = request.user.sub;
+
+    const useCase = makeGetMyMatchPredictionsUseCase();
+    const { predictions } = await useCase.execute({ matchId, userId });
+
+    return reply.status(200).send({ predictions });
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return reply.status(404).send({ message: error.message });
+    }
+
+    if (error instanceof z.ZodError) {
+      return reply.status(422).send({ message: 'Validation error', issues: error.format() });
+    }
+
+    throw error;
+  }
+}

--- a/src/http/routes/matches.routes.ts
+++ b/src/http/routes/matches.routes.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from 'fastify';
 import { getMatchController } from '@/http/controllers/matches/getMatchController';
 import { getMatchPredictionsController } from '@/http/controllers/matches/getMatchPredictionsController';
 import { updateMatchController } from '@/http/controllers/matches/updateMatchController';
+import { getMyMatchPredictionsController } from '@/http/controllers/predictions/getMyMatchPredictionsController';
 import { verifySupabaseToken } from '@/http/middlewares/verifySupabaseToken';
 import { commonSchemas } from '@/http/schemas/common.schemas';
 import { matchSchemas } from '@/http/schemas/match.schemas';
@@ -80,6 +81,42 @@ export function matchesRoutes(app: FastifyInstance): void {
       },
     },
     getMatchPredictionsController
+  );
+
+  app.get(
+    '/matches/:matchId/predictions/me',
+    {
+      schema: {
+        tags: ['Matches'],
+        summary: "Get my prediction status for a match",
+        description:
+          "Returns the authenticated user's prediction (or null if not submitted) for a specific match across all pools the user participates in for that tournament.",
+        params: matchSchemas.MatchIdParam,
+        response: {
+          200: {
+            description: 'Prediction status retrieved successfully',
+            ...matchSchemas.GetMyMatchPredictionsResponse,
+          },
+          401: {
+            description: 'Unauthorized access',
+            ...commonSchemas.UnauthorizedError,
+          },
+          404: {
+            description: 'Match not found',
+            ...commonSchemas.MatchNotFoundError,
+          },
+          422: {
+            description: 'Validation error',
+            ...matchSchemas.MatchValidationError,
+          },
+          500: {
+            description: 'Internal server error',
+            ...matchSchemas.MatchInternalServerError,
+          },
+        },
+      },
+    },
+    getMyMatchPredictionsController
   );
 
   app.put(

--- a/src/http/schemas/match.schemas.ts
+++ b/src/http/schemas/match.schemas.ts
@@ -244,4 +244,38 @@ export const matchSchemas = {
       match: { $ref: 'MatchWithTeams#' },
     },
   },
+
+  GetMyMatchPredictionsResponse: {
+    type: 'object',
+    properties: {
+      predictions: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            poolId: { type: 'number' },
+            poolName: { type: 'string' },
+            matchId: { type: 'number' },
+            prediction: {
+              nullable: true,
+              type: 'object',
+              properties: {
+                id: { type: 'number' },
+                predictedHomeScore: { type: 'number' },
+                predictedAwayScore: { type: 'number' },
+                predictedHasExtraTime: { type: 'boolean' },
+                predictedHasPenalties: { type: 'boolean' },
+                predictedPenaltyHomeScore: { type: 'number', nullable: true },
+                predictedPenaltyAwayScore: { type: 'number', nullable: true },
+                pointsEarned: { type: 'number', nullable: true },
+                submittedAt: { type: 'string', format: 'date-time' },
+                updatedAt: { type: 'string', format: 'date-time', nullable: true },
+              },
+            },
+          },
+          required: ['poolId', 'poolName', 'matchId', 'prediction'],
+        },
+      },
+    },
+  },
 };

--- a/src/repositories/pools/IPoolsRepository.ts
+++ b/src/repositories/pools/IPoolsRepository.ts
@@ -7,6 +7,24 @@ export type PoolCompleteInfo = Prisma.PoolGetPayload<{
   include: { participants: true; scoringRules: true };
 }>;
 
+export type PoolPredictionEntry = {
+  poolId: number;
+  poolName: string;
+  matchId: number;
+  prediction: {
+    id: number;
+    predictedHomeScore: number;
+    predictedAwayScore: number;
+    predictedHasExtraTime: boolean;
+    predictedHasPenalties: boolean;
+    predictedPenaltyHomeScore: number | null;
+    predictedPenaltyAwayScore: number | null;
+    pointsEarned: number | null;
+    submittedAt: Date;
+    updatedAt: Date | null;
+  } | null;
+};
+
 export interface IPoolsRepository {
   create(data: Prisma.PoolCreateInput): Promise<Pool>;
   createScoringRules(data: Prisma.ScoringRuleCreateInput): Promise<ScoringRule>;
@@ -30,4 +48,9 @@ export interface IPoolsRepository {
   getUserPoolsStandings(userId: string): Promise<PoolStandings[]>;
   findByName(name: string): Promise<Pool | null>;
   deletePoolById(poolId: number): Promise<void>;
+  getPoolsWithUserPredictionForMatch(params: {
+    tournamentId: number;
+    matchId: number;
+    userId: string;
+  }): Promise<PoolPredictionEntry[]>;
 }

--- a/src/repositories/pools/InMemoryPoolsRepository.ts
+++ b/src/repositories/pools/InMemoryPoolsRepository.ts
@@ -5,7 +5,7 @@ import { PoolParticipant } from '@/global/types/poolParticipant';
 import { PoolStandings } from '@/global/types/poolStandings';
 import { PredictionPoints } from '@/global/types/predictionPoints';
 
-import { IPoolsRepository, PoolCompleteInfo } from './IPoolsRepository';
+import { IPoolsRepository, PoolCompleteInfo, PoolPredictionEntry } from './IPoolsRepository';
 
 export class InMemoryPoolsRepository implements IPoolsRepository {
   public pools: Pool[] = [];
@@ -403,5 +403,50 @@ export class InMemoryPoolsRepository implements IPoolsRepository {
   }
   deletePoolById(_poolId: number): Promise<void> {
     throw new Error('Method not implemented.');
+  }
+
+  async getPoolsWithUserPredictionForMatch({
+    tournamentId,
+    matchId,
+    userId,
+  }: {
+    tournamentId: number;
+    matchId: number;
+    userId: string;
+  }): Promise<PoolPredictionEntry[]> {
+    const userPoolIds = this.participants
+      .filter((p) => p.userId === userId)
+      .map((p) => p.poolId);
+
+    const eligiblePools = this.pools.filter(
+      (pool) => pool.tournamentId === tournamentId && userPoolIds.includes(pool.id)
+    );
+
+    return eligiblePools.map((pool) => {
+      const found =
+        this.predictions.find(
+          (pred) => pred.poolId === pool.id && pred.matchId === matchId && pred.userId === userId
+        ) ?? null;
+
+      return {
+        poolId: pool.id,
+        poolName: pool.name,
+        matchId,
+        prediction: found
+          ? {
+              id: found.id,
+              predictedHomeScore: found.predictedHomeScore,
+              predictedAwayScore: found.predictedAwayScore,
+              predictedHasExtraTime: found.predictedHasExtraTime,
+              predictedHasPenalties: found.predictedHasPenalties,
+              predictedPenaltyHomeScore: found.predictedPenaltyHomeScore,
+              predictedPenaltyAwayScore: found.predictedPenaltyAwayScore,
+              pointsEarned: found.pointsEarned ?? null,
+              submittedAt: found.submittedAt,
+              updatedAt: found.updatedAt ?? null,
+            }
+          : null,
+      };
+    });
   }
 }

--- a/src/repositories/pools/PrismaPoolsRepository.ts
+++ b/src/repositories/pools/PrismaPoolsRepository.ts
@@ -4,7 +4,7 @@ import { InviteCodeInUseError } from '@/global/errors/InviteCodeInUseError';
 import { PoolParticipant } from '@/global/types/poolParticipant';
 import { PoolStandings } from '@/global/types/poolStandings';
 
-import { IPoolsRepository, PoolCompleteInfo } from './IPoolsRepository';
+import { IPoolsRepository, PoolCompleteInfo, PoolPredictionEntry } from './IPoolsRepository';
 import { prisma } from '../../lib/prisma';
 
 export class PrismaPoolsRepository implements IPoolsRepository {
@@ -256,5 +256,49 @@ export class PrismaPoolsRepository implements IPoolsRepository {
     await prisma.pool.delete({
       where: { id: poolId },
     });
+  }
+
+  async getPoolsWithUserPredictionForMatch({
+    tournamentId,
+    matchId,
+    userId,
+  }: {
+    tournamentId: number;
+    matchId: number;
+    userId: string;
+  }): Promise<PoolPredictionEntry[]> {
+    const pools = await prisma.pool.findMany({
+      where: {
+        tournamentId,
+        participants: { some: { userId } },
+      },
+      select: {
+        id: true,
+        name: true,
+        predictions: {
+          where: { matchId, userId },
+          select: {
+            id: true,
+            predictedHomeScore: true,
+            predictedAwayScore: true,
+            predictedHasExtraTime: true,
+            predictedHasPenalties: true,
+            predictedPenaltyHomeScore: true,
+            predictedPenaltyAwayScore: true,
+            pointsEarned: true,
+            submittedAt: true,
+            updatedAt: true,
+          },
+          take: 1,
+        },
+      },
+    });
+
+    return pools.map((pool) => ({
+      poolId: pool.id,
+      poolName: pool.name,
+      matchId,
+      prediction: pool.predictions[0] ?? null,
+    }));
   }
 }

--- a/src/useCases/predictions/factories/makeGetMyMatchPredictionsUseCase.ts
+++ b/src/useCases/predictions/factories/makeGetMyMatchPredictionsUseCase.ts
@@ -1,0 +1,11 @@
+import { PrismaMatchesRepository } from '@/repositories/matches/PrismaMatchesRepository';
+import { PrismaPoolsRepository } from '@/repositories/pools/PrismaPoolsRepository';
+
+import { GetMyMatchPredictionsUseCase } from '../getMyMatchPredictionsUseCase';
+
+export function makeGetMyMatchPredictionsUseCase(): GetMyMatchPredictionsUseCase {
+  const matchesRepository = new PrismaMatchesRepository();
+  const poolsRepository = new PrismaPoolsRepository();
+
+  return new GetMyMatchPredictionsUseCase(matchesRepository, poolsRepository);
+}

--- a/src/useCases/predictions/getMyMatchPredictionsUseCase.spec.ts
+++ b/src/useCases/predictions/getMyMatchPredictionsUseCase.spec.ts
@@ -1,0 +1,197 @@
+import { MatchStage, MatchStatus } from '@prisma/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { InMemoryMatchesRepository } from '@/repositories/matches/InMemoryMatchesRepository';
+import { InMemoryPoolsRepository } from '@/repositories/pools/InMemoryPoolsRepository';
+import { InMemoryPredictionsRepository } from '@/repositories/predictions/InMemoryPredictionsRepository';
+import { createPool } from '@/test/mocks/pools';
+import { createPrediction } from '@/test/mocks/predictions';
+
+import { GetMyMatchPredictionsUseCase } from './getMyMatchPredictionsUseCase';
+
+const TOURNAMENT_ID = 1;
+const MATCH_ID = 42;
+const USER_ID = 'user-01';
+const OTHER_USER_ID = 'user-02';
+
+describe('GetMyMatchPredictionsUseCase', () => {
+  let matchesRepository: InMemoryMatchesRepository;
+  let poolsRepository: InMemoryPoolsRepository;
+  let predictionsRepository: InMemoryPredictionsRepository;
+  let sut: GetMyMatchPredictionsUseCase;
+
+  beforeEach(() => {
+    matchesRepository = new InMemoryMatchesRepository();
+    poolsRepository = new InMemoryPoolsRepository();
+    predictionsRepository = new InMemoryPredictionsRepository();
+
+    sut = new GetMyMatchPredictionsUseCase(matchesRepository, poolsRepository);
+
+    matchesRepository.matches.push({
+      id: MATCH_ID,
+      tournamentId: TOURNAMENT_ID,
+      homeTeamId: 1,
+      awayTeamId: 2,
+      matchDatetime: new Date('2026-06-15T15:00:00Z'),
+      stadium: null,
+      stage: MatchStage.GROUP,
+      group: null,
+      homeTeamScore: null,
+      awayTeamScore: null,
+      matchStatus: MatchStatus.SCHEDULED,
+      hasExtraTime: false,
+      hasPenalties: false,
+      penaltyHomeScore: null,
+      penaltyAwayScore: null,
+      createdAt: new Date(),
+      updatedAt: null,
+    });
+  });
+
+  it('should return one entry per pool the user belongs to', async () => {
+    await createPool(poolsRepository, { tournamentId: TOURNAMENT_ID, creatorId: USER_ID });
+    await createPool(poolsRepository, { tournamentId: TOURNAMENT_ID, creatorId: USER_ID });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toHaveLength(2);
+  });
+
+  it('should include a prediction object where one was submitted', async () => {
+    const pool = await createPool(poolsRepository, {
+      tournamentId: TOURNAMENT_ID,
+      creatorId: USER_ID,
+    });
+
+    await createPrediction(predictionsRepository, {
+      userId: USER_ID,
+      matchId: MATCH_ID,
+      poolId: pool.id,
+      predictedHomeScore: 2,
+      predictedAwayScore: 1,
+    });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toHaveLength(1);
+    expect(predictions[0].prediction).not.toBeNull();
+    expect(predictions[0].prediction?.predictedHomeScore).toBe(2);
+    expect(predictions[0].prediction?.predictedAwayScore).toBe(1);
+    expect(predictions[0].poolId).toBe(pool.id);
+    expect(predictions[0].matchId).toBe(MATCH_ID);
+  });
+
+  it('should set prediction to null where no prediction was submitted', async () => {
+    await createPool(poolsRepository, { tournamentId: TOURNAMENT_ID, creatorId: USER_ID });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toHaveLength(1);
+    expect(predictions[0].prediction).toBeNull();
+  });
+
+  it('should mix pools with and without predictions correctly', async () => {
+    const poolA = await createPool(poolsRepository, {
+      tournamentId: TOURNAMENT_ID,
+      creatorId: USER_ID,
+    });
+    const poolB = await createPool(poolsRepository, {
+      tournamentId: TOURNAMENT_ID,
+      creatorId: USER_ID,
+    });
+
+    await createPrediction(predictionsRepository, {
+      userId: USER_ID,
+      matchId: MATCH_ID,
+      poolId: poolA.id,
+      predictedHomeScore: 3,
+      predictedAwayScore: 0,
+    });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    const entryA = predictions.find((p) => p.poolId === poolA.id);
+    const entryB = predictions.find((p) => p.poolId === poolB.id);
+
+    expect(entryA?.prediction).not.toBeNull();
+    expect(entryA?.prediction?.predictedHomeScore).toBe(3);
+    expect(entryB?.prediction).toBeNull();
+  });
+
+  it('should return an empty array when user belongs to no pools for the tournament', async () => {
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toEqual([]);
+  });
+
+  it('should throw ResourceNotFoundError when match does not exist', async () => {
+    await expect(sut.execute({ matchId: 999, userId: USER_ID })).rejects.toBeInstanceOf(
+      ResourceNotFoundError
+    );
+  });
+
+  it('should not include pools from a different tournament', async () => {
+    await createPool(poolsRepository, {
+      tournamentId: TOURNAMENT_ID + 99,
+      creatorId: USER_ID,
+    });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toEqual([]);
+  });
+
+  it('should not include pools where the user is not a participant', async () => {
+    await createPool(poolsRepository, {
+      tournamentId: TOURNAMENT_ID,
+      creatorId: OTHER_USER_ID,
+    });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toEqual([]);
+  });
+
+  it('should not include predictions from other users in the same pool', async () => {
+    const pool = await createPool(poolsRepository, {
+      tournamentId: TOURNAMENT_ID,
+      creatorId: USER_ID,
+    });
+
+    await createPrediction(predictionsRepository, {
+      userId: OTHER_USER_ID,
+      matchId: MATCH_ID,
+      poolId: pool.id,
+      predictedHomeScore: 1,
+      predictedAwayScore: 1,
+    });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions).toHaveLength(1);
+    expect(predictions[0].prediction).toBeNull();
+  });
+
+  it('should include the pool name in each entry', async () => {
+    await createPool(poolsRepository, {
+      name: 'Bolão da Família',
+      tournamentId: TOURNAMENT_ID,
+      creatorId: USER_ID,
+    });
+    poolsRepository.predictions = predictionsRepository.predictions;
+
+    const { predictions } = await sut.execute({ matchId: MATCH_ID, userId: USER_ID });
+
+    expect(predictions[0].poolName).toBe('Bolão da Família');
+  });
+});

--- a/src/useCases/predictions/getMyMatchPredictionsUseCase.ts
+++ b/src/useCases/predictions/getMyMatchPredictionsUseCase.ts
@@ -1,0 +1,38 @@
+import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
+import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
+import { IPoolsRepository, PoolPredictionEntry } from '@/repositories/pools/IPoolsRepository';
+
+interface GetMyMatchPredictionsUseCaseRequest {
+  matchId: number;
+  userId: string;
+}
+
+interface GetMyMatchPredictionsUseCaseResponse {
+  predictions: PoolPredictionEntry[];
+}
+
+export class GetMyMatchPredictionsUseCase {
+  constructor(
+    private matchesRepository: IMatchesRepository,
+    private poolsRepository: IPoolsRepository
+  ) {}
+
+  async execute({
+    matchId,
+    userId,
+  }: GetMyMatchPredictionsUseCaseRequest): Promise<GetMyMatchPredictionsUseCaseResponse> {
+    const match = await this.matchesRepository.findById(matchId);
+
+    if (!match) {
+      throw new ResourceNotFoundError('Match not found');
+    }
+
+    const predictions = await this.poolsRepository.getPoolsWithUserPredictionForMatch({
+      tournamentId: match.tournamentId,
+      matchId,
+      userId,
+    });
+
+    return { predictions };
+  }
+}


### PR DESCRIPTION
Returns the authenticated user's prediction status for a match across all pools they participate in for that tournament. Each pool appears in the response regardless of whether a prediction was submitted, allowing the mobile app to surface missing predictions with a direct CTA.

Implemented with two DB queries: match lookup + a single pool.findMany with nested prediction filter. Includes unit and e2e tests.