### PR TITLE
feat: implement get tournament matches endpoint

### DIFF
--- a/src/http/controllers/tournaments/getTournamentMatchesController.e2e.spec.ts
+++ b/src/http/controllers/tournaments/getTournamentMatchesController.e2e.spec.ts
@@ -1,4 +1,3 @@
-import { Match } from '@prisma/client';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -14,7 +13,14 @@ import { createMatchWithTeams } from '@/test/mocks/match';
 import { createTournament } from '@/test/mocks/tournament';
 
 type TournamentMatchesResponse = {
-  matches: Array<Match>;
+  matches: Array<{
+    id: number;
+    tournamentId: number;
+    homeTeamId: number;
+    awayTeamId: number;
+    homeTeam: { id: number; name: string; countryCode: string | null; flagUrl: string | null };
+    awayTeam: { id: number; name: string; countryCode: string | null; flagUrl: string | null };
+  }>;
 };
 
 describe('GET /tournaments/:tournamentId/matches', async () => {
@@ -49,6 +55,12 @@ describe('GET /tournaments/:tournamentId/matches', async () => {
     const body = response.body as TournamentMatchesResponse;
     expect(body.matches).toBeInstanceOf(Array);
     expect(body.matches.length).toBe(3);
+    expect(body.matches[0].homeTeam).toBeDefined();
+    expect(body.matches[0].awayTeam).toBeDefined();
+    expect(body.matches[0].homeTeam).toHaveProperty('id');
+    expect(body.matches[0].homeTeam).toHaveProperty('name');
+    expect(body.matches[0].homeTeam).toHaveProperty('flagUrl');
+    expect(body.matches[0].awayTeam).toHaveProperty('flagUrl');
   });
 
   it('should require authentication', async () => {

--- a/src/http/routes/tournaments.routes.ts
+++ b/src/http/routes/tournaments.routes.ts
@@ -82,7 +82,7 @@ export function tournamentsRoutes(app: FastifyInstance): void {
             properties: {
               matches: {
                 type: 'array',
-                items: matchSchemas.Match,
+                items: { $ref: 'MatchWithTeams#' },
               },
             },
             required: ['matches'],

--- a/src/repositories/matches/IMatchesRepository.ts
+++ b/src/repositories/matches/IMatchesRepository.ts
@@ -1,8 +1,11 @@
-import { Match, Prisma } from '@prisma/client';
+import { Match, Team, Prisma } from '@prisma/client';
+
+export type MatchWithTeams = Match & { homeTeam: Team; awayTeam: Team };
+
 export interface IMatchesRepository {
   create(data: Prisma.MatchCreateInput): Promise<Match>;
   findById(id: number): Promise<Match | null>;
-  findByTournamentId(tournamentId: number): Promise<Match[]>;
+  findByTournamentId(tournamentId: number): Promise<MatchWithTeams[]>;
   findUpcomingMatches(tournamentId: number): Promise<Match[]>;
   findCompletedMatches(tournamentId: number): Promise<Match[]>;
   update(id: number, data: Prisma.MatchUpdateInput): Promise<Match>;

--- a/src/repositories/matches/InMemoryMatchesRepository.ts
+++ b/src/repositories/matches/InMemoryMatchesRepository.ts
@@ -1,6 +1,6 @@
 import { Match, MatchStage, MatchStatus, Prisma, Team, Tournament } from '@prisma/client';
 
-import { IMatchesRepository } from './IMatchesRepository';
+import { IMatchesRepository, MatchWithTeams } from './IMatchesRepository';
 
 export class InMemoryMatchesRepository implements IMatchesRepository {
   public matches: Match[] = [];
@@ -38,10 +38,15 @@ export class InMemoryMatchesRepository implements IMatchesRepository {
     return Promise.resolve(match || null);
   }
 
-  findByTournamentId(tournamentId: number): Promise<Match[]> {
+  findByTournamentId(tournamentId: number): Promise<MatchWithTeams[]> {
     const matches = this.matches
       .filter((match) => match.tournamentId === tournamentId)
-      .sort((a, b) => a.matchDatetime.getTime() - b.matchDatetime.getTime());
+      .sort((a, b) => a.matchDatetime.getTime() - b.matchDatetime.getTime())
+      .map((match) => ({
+        ...match,
+        homeTeam: this.teams.find((t) => t.id === match.homeTeamId) as Team,
+        awayTeam: this.teams.find((t) => t.id === match.awayTeamId) as Team,
+      }));
 
     return Promise.resolve(matches);
   }

--- a/src/repositories/matches/PrismaMatchesRepository.ts
+++ b/src/repositories/matches/PrismaMatchesRepository.ts
@@ -1,6 +1,6 @@
 import { Match, MatchStatus, Prisma } from '@prisma/client';
 
-import { IMatchesRepository } from './IMatchesRepository';
+import { IMatchesRepository, MatchWithTeams } from './IMatchesRepository';
 import { prisma } from '../../lib/prisma';
 
 export class PrismaMatchesRepository implements IMatchesRepository {
@@ -20,10 +20,11 @@ export class PrismaMatchesRepository implements IMatchesRepository {
     return match;
   }
 
-  async findByTournamentId(tournamentId: number): Promise<Match[]> {
+  async findByTournamentId(tournamentId: number): Promise<MatchWithTeams[]> {
     const matches = await prisma.match.findMany({
       where: { tournamentId },
       orderBy: { matchDatetime: 'asc' },
+      include: { homeTeam: true, awayTeam: true },
     });
 
     return matches;

--- a/src/useCases/tournaments/getTournamentMatchesUseCase.spec.ts
+++ b/src/useCases/tournaments/getTournamentMatchesUseCase.spec.ts
@@ -30,6 +30,17 @@ describe('Get Tournament Matches Use Case', () => {
       endDate: new Date(),
     });
 
+    // Seed teams into the in-memory repository
+    for (let i = 1; i <= 6; i++) {
+      matchesRepository.teams.push({
+        id: i,
+        name: `Team ${i}`,
+        countryCode: null,
+        flagUrl: `https://example.com/flags/${i}.png`,
+        createdAt: new Date(),
+      });
+    }
+
     for (let i = 1; i <= 3; i++) {
       await matchesRepository.create({
         tournament: { connect: { id: tournament1.id } },
@@ -51,6 +62,9 @@ describe('Get Tournament Matches Use Case', () => {
     // Assert
     expect(matches).toHaveLength(3);
     expect(matches.every((m) => m.tournamentId === tournament1.id)).toBe(true);
+    expect(matches[0].homeTeam).toBeDefined();
+    expect(matches[0].awayTeam).toBeDefined();
+    expect(matches[0].homeTeam.flagUrl).toBe('https://example.com/flags/1.png');
   });
 
   it('should throw if tournament does not exist', async () => {

--- a/src/useCases/tournaments/getTournamentMatchesUseCase.ts
+++ b/src/useCases/tournaments/getTournamentMatchesUseCase.ts
@@ -1,7 +1,5 @@
-import { Match } from '@prisma/client';
-
 import { ResourceNotFoundError } from '@/global/errors/ResourceNotFoundError';
-import { IMatchesRepository } from '@/repositories/matches/IMatchesRepository';
+import { IMatchesRepository, MatchWithTeams } from '@/repositories/matches/IMatchesRepository';
 import { ITournamentsRepository } from '@/repositories/tournaments/ITournamentsRepository';
 
 interface GetTournamentMatchesUseCaseRequest {
@@ -9,7 +7,7 @@ interface GetTournamentMatchesUseCaseRequest {
 }
 
 interface GetTournamentMatchesUseCaseResponse {
-  matches: Match[];
+  matches: MatchWithTeams[];
 }
 
 export class GetTournamentMatchesUseCase {


### PR DESCRIPTION
Add GET /tournaments/:tournamentId/matches endpoint with use case, repository methods, and e2e tests.